### PR TITLE
Implement basic admin role for deleting users

### DIFF
--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, email: payload.email };
+    return { userId: payload.sub, email: payload.email, role: payload.role };
   }
 }

--- a/src/auth/roles.decorator.ts
+++ b/src/auth/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../user/entity/user.entity';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+import { Role } from '../user/entity/user.entity';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user.role);
+  }
+}

--- a/src/auth/service/auth.service.ts
+++ b/src/auth/service/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
   }
 
   async login(user: any) {
-    const payload = { sub: user.id, email: user.email };
+    const payload = { sub: user.id, email: user.email, role: user.role };
     return {
       access_token: this.jwtService.sign(payload),
     };

--- a/src/user/controller/user.controller.ts
+++ b/src/user/controller/user.controller.ts
@@ -14,6 +14,9 @@ import {
 import { UserService } from '../service/user.service';
 import { CreateUserDto } from '../dto/create-user.dto';
 import { AuthGuard } from '@nestjs/passport';
+import { Roles } from 'src/auth/roles.decorator';
+import { RolesGuard } from 'src/auth/roles.guard';
+import { Role } from '../entity/user.entity';
 import { GetUserProfileResponse } from './response/get-user-profile.response';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
@@ -58,7 +61,8 @@ export class UserController {
     return GetUserProfileResponse.create(user);
   }
 
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(Role.ADMIN)
   @Delete(':id')
   async remove(@Param('id', new ParseUUIDPipe()) id: string) {
     await this.userService.delete(id);

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -6,6 +6,11 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+export enum Role {
+  USER = 'user',
+  ADMIN = 'admin',
+}
+
 @Entity()
 export class User {
   @PrimaryGeneratedColumn('uuid')
@@ -25,6 +30,9 @@ export class User {
 
   @Column()
   lastName: string;
+
+  @Column({ type: 'enum', enum: Role, default: Role.USER })
+  role: Role;
 
   @Column({ default: true })
   isActive: boolean;

--- a/src/user/repository/user.repository.ts
+++ b/src/user/repository/user.repository.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../entity/user.entity';
-import { CreateUserDto } from '../dto/create-user.dto';
 
 @Injectable()
 export class UserRepository {
@@ -19,7 +18,7 @@ export class UserRepository {
     return this.repository.findOneBy({ id });
   }
 
-  async createAndSave(userData: CreateUserDto): Promise<User> {
+  async createAndSave(userData: Partial<User>): Promise<User> {
     const newUser = this.repository.create(userData);
     return this.repository.save(newUser);
   }

--- a/src/user/service/user.service.ts
+++ b/src/user/service/user.service.ts
@@ -1,6 +1,6 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { UserRepository } from '../repository/user.repository';
-import { User } from '../entity/user.entity';
+import { User, Role } from '../entity/user.entity';
 import { CreateUserDto } from '../dto/create-user.dto';
 import * as bcrypt from 'bcrypt';
 import { MailService } from 'src/mail/services/mail.service';
@@ -34,8 +34,9 @@ export class UserService {
     const userWithHashedPassword = {
       ...userData,
       password: hashedPassword,
+      role: Role.USER,
     };
-    
+
     const user = await this.userRepository.createAndSave(userWithHashedPassword);
       
     const token = this.jwtService.sign(


### PR DESCRIPTION
## Summary
- create Role enum and role field on User entity
- emit user role in JWT token during login and validation
- add Roles decorator and RolesGuard for role checking
- restrict user deletion endpoint to admin role
- set new users to default 'user' role

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e87a194483209ba49edbb8a39955