### PR TITLE
Add card search module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from 'src/auth/auth.module';
 import { AppController } from 'src/app.controller';
 import { AppService } from 'src/app.service';
 import { UserModule } from './user/user.module';
+import { CardModule } from './card/card.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { UserModule } from './user/user.module';
     }),
     UserModule,
     AuthModule,
+    CardModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/card/card.module.ts
+++ b/src/card/card.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CardService } from './service/card.service';
+import { CardController } from './controller/card.controller';
+
+@Module({
+  controllers: [CardController],
+  providers: [CardService],
+  exports: [CardService],
+})
+export class CardModule {}

--- a/src/card/controller/card.controller.ts
+++ b/src/card/controller/card.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { CardService } from '../service/card.service';
+
+@Controller('cards')
+export class CardController {
+  constructor(private readonly cardService: CardService) {}
+
+  @Get('search')
+  search(@Query('q') query: string) {
+    return this.cardService.search(query);
+  }
+}

--- a/src/card/service/card.service.spec.ts
+++ b/src/card/service/card.service.spec.ts
@@ -1,0 +1,37 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CardService } from './card.service';
+
+describe('CardService', () => {
+  let service: CardService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CardService],
+    }).compile();
+
+    service = module.get<CardService>(CardService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should fetch cards from scryfall', async () => {
+    const data = { data: [] };
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(data),
+    } as any);
+
+    const result = await service.search('test');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.scryfall.com/cards/search?q=test',
+    );
+    expect(result).toEqual(data);
+  });
+});

--- a/src/card/service/card.service.ts
+++ b/src/card/service/card.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CardService {
+  private readonly apiUrl = 'https://api.scryfall.com';
+
+  async search(query: string): Promise<any> {
+    const response = await fetch(
+      `${this.apiUrl}/cards/search?q=${encodeURIComponent(query)}`,
+    );
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch cards');
+    }
+
+    return response.json();
+  }
+}


### PR DESCRIPTION
## Summary
- add `CardModule` with controller and service
- integrate `CardModule` into `AppModule`
- implement unit tests for `CardService`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846175b9f4c832085e697007526250c