### PR TITLE
Add collection module with inventory and wishlist

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AppController } from 'src/app.controller';
 import { AppService } from 'src/app.service';
 import { UserModule } from './user/user.module';
 import { CardModule } from './card/card.module';
+import { CollectionModule } from './collection/collection.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { CardModule } from './card/card.module';
     UserModule,
     AuthModule,
     CardModule,
+    CollectionModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/collection/collection.module.ts
+++ b/src/collection/collection.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Card } from './entity/card.entity';
+import { InventoryItem } from './entity/inventory-item.entity';
+import { WishlistItem } from './entity/wishlist-item.entity';
+import { CardRepository } from './repository/card.repository';
+import { InventoryItemRepository } from './repository/inventory-item.repository';
+import { WishlistItemRepository } from './repository/wishlist-item.repository';
+import { CardService } from './service/card.service';
+import { InventoryService } from './service/inventory.service';
+import { WishlistService } from './service/wishlist.service';
+import { InventoryController } from './controller/inventory.controller';
+import { WishlistController } from './controller/wishlist.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Card, InventoryItem, WishlistItem])],
+  controllers: [InventoryController, WishlistController],
+  providers: [
+    CardRepository,
+    InventoryItemRepository,
+    WishlistItemRepository,
+    CardService,
+    InventoryService,
+    WishlistService,
+  ],
+  exports: [CardService, InventoryService, WishlistService],
+})
+export class CollectionModule {}

--- a/src/collection/controller/inventory.controller.ts
+++ b/src/collection/controller/inventory.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, Post, Body, Param, Delete, Put, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
+import { InventoryService } from '../service/inventory.service';
+import { CreateInventoryItemDto } from '../dto/create-inventory-item.dto';
+import { UpdateInventoryItemDto } from '../dto/update-inventory-item.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+@UseGuards(AuthGuard('jwt'))
+@Controller('inventory')
+export class InventoryController {
+  constructor(private readonly inventoryService: InventoryService) {}
+
+  @Get()
+  findAll(@Request() req) {
+    return this.inventoryService.findByUser(req.user.userId);
+  }
+
+  @Post()
+  create(@Request() req, @Body() dto: CreateInventoryItemDto) {
+    const userId = req.user.userId;
+    return this.inventoryService.create({
+      user: { id: userId } as any,
+      card: { id: dto.cardId } as any,
+      quantity: dto.quantity,
+    });
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: UpdateInventoryItemDto,
+  ) {
+    return this.inventoryService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.inventoryService.remove(id);
+  }
+}

--- a/src/collection/controller/wishlist.controller.ts
+++ b/src/collection/controller/wishlist.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, Post, Body, Param, Delete, Put, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
+import { WishlistService } from '../service/wishlist.service';
+import { CreateWishlistItemDto } from '../dto/create-wishlist-item.dto';
+import { UpdateWishlistItemDto } from '../dto/update-wishlist-item.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+@UseGuards(AuthGuard('jwt'))
+@Controller('wishlist')
+export class WishlistController {
+  constructor(private readonly wishlistService: WishlistService) {}
+
+  @Get()
+  findAll(@Request() req) {
+    return this.wishlistService.findByUser(req.user.userId);
+  }
+
+  @Post()
+  create(@Request() req, @Body() dto: CreateWishlistItemDto) {
+    const userId = req.user.userId;
+    return this.wishlistService.create({
+      user: { id: userId } as any,
+      card: { id: dto.cardId } as any,
+      desiredQuantity: dto.desiredQuantity,
+    });
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: UpdateWishlistItemDto,
+  ) {
+    return this.wishlistService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.wishlistService.remove(id);
+  }
+}

--- a/src/collection/dto/create-inventory-item.dto.ts
+++ b/src/collection/dto/create-inventory-item.dto.ts
@@ -1,0 +1,4 @@
+export class CreateInventoryItemDto {
+  cardId: string;
+  quantity: number;
+}

--- a/src/collection/dto/create-wishlist-item.dto.ts
+++ b/src/collection/dto/create-wishlist-item.dto.ts
@@ -1,0 +1,4 @@
+export class CreateWishlistItemDto {
+  cardId: string;
+  desiredQuantity: number;
+}

--- a/src/collection/dto/update-inventory-item.dto.ts
+++ b/src/collection/dto/update-inventory-item.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateInventoryItemDto {
+  quantity?: number;
+}

--- a/src/collection/dto/update-wishlist-item.dto.ts
+++ b/src/collection/dto/update-wishlist-item.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateWishlistItemDto {
+  desiredQuantity?: number;
+}

--- a/src/collection/entity/card.entity.ts
+++ b/src/collection/entity/card.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Card {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  imageUrl?: string;
+}

--- a/src/collection/entity/inventory-item.entity.ts
+++ b/src/collection/entity/inventory-item.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { User } from 'src/user/entity/user.entity';
+import { Card } from './card.entity';
+
+@Entity()
+export class InventoryItem {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, { eager: true })
+  user: User;
+
+  @ManyToOne(() => Card, { eager: true, cascade: true })
+  card: Card;
+
+  @Column({ default: 1 })
+  quantity: number;
+}

--- a/src/collection/entity/wishlist-item.entity.ts
+++ b/src/collection/entity/wishlist-item.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { User } from 'src/user/entity/user.entity';
+import { Card } from './card.entity';
+
+@Entity()
+export class WishlistItem {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, { eager: true })
+  user: User;
+
+  @ManyToOne(() => Card, { eager: true, cascade: true })
+  card: Card;
+
+  @Column({ default: 1 })
+  desiredQuantity: number;
+}

--- a/src/collection/repository/card.repository.ts
+++ b/src/collection/repository/card.repository.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Card } from '../entity/card.entity';
+
+@Injectable()
+export class CardRepository {
+  constructor(
+    @InjectRepository(Card)
+    private readonly repository: Repository<Card>,
+  ) {}
+
+  findAll(): Promise<Card[]> {
+    return this.repository.find();
+  }
+
+  findById(id: string): Promise<Card | null> {
+    return this.repository.findOneBy({ id });
+  }
+
+  async createAndSave(data: Partial<Card>): Promise<Card> {
+    const card = this.repository.create(data);
+    return this.repository.save(card);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.repository.delete(id);
+  }
+}

--- a/src/collection/repository/inventory-item.repository.ts
+++ b/src/collection/repository/inventory-item.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InventoryItem } from '../entity/inventory-item.entity';
+
+@Injectable()
+export class InventoryItemRepository {
+  constructor(
+    @InjectRepository(InventoryItem)
+    private readonly repository: Repository<InventoryItem>,
+  ) {}
+
+  findByUser(userId: string): Promise<InventoryItem[]> {
+    return this.repository.find({ where: { user: { id: userId } } });
+  }
+
+  findById(id: string): Promise<InventoryItem | null> {
+    return this.repository.findOne({ where: { id } });
+  }
+
+  async createAndSave(data: Partial<InventoryItem>): Promise<InventoryItem> {
+    const item = this.repository.create(data);
+    return this.repository.save(item);
+  }
+
+  async update(id: string, data: Partial<InventoryItem>): Promise<InventoryItem> {
+    await this.repository.update(id, data);
+    return this.repository.findOneBy({ id });
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.repository.delete(id);
+  }
+}

--- a/src/collection/repository/wishlist-item.repository.ts
+++ b/src/collection/repository/wishlist-item.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WishlistItem } from '../entity/wishlist-item.entity';
+
+@Injectable()
+export class WishlistItemRepository {
+  constructor(
+    @InjectRepository(WishlistItem)
+    private readonly repository: Repository<WishlistItem>,
+  ) {}
+
+  findByUser(userId: string): Promise<WishlistItem[]> {
+    return this.repository.find({ where: { user: { id: userId } } });
+  }
+
+  findById(id: string): Promise<WishlistItem | null> {
+    return this.repository.findOne({ where: { id } });
+  }
+
+  async createAndSave(data: Partial<WishlistItem>): Promise<WishlistItem> {
+    const item = this.repository.create(data);
+    return this.repository.save(item);
+  }
+
+  async update(id: string, data: Partial<WishlistItem>): Promise<WishlistItem> {
+    await this.repository.update(id, data);
+    return this.repository.findOneBy({ id });
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.repository.delete(id);
+  }
+}

--- a/src/collection/service/card.service.ts
+++ b/src/collection/service/card.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { CardRepository } from '../repository/card.repository';
+import { Card } from '../entity/card.entity';
+
+@Injectable()
+export class CardService {
+  constructor(private readonly cardRepository: CardRepository) {}
+
+  findAll(): Promise<Card[]> {
+    return this.cardRepository.findAll();
+  }
+
+  findById(id: string): Promise<Card | null> {
+    return this.cardRepository.findById(id);
+  }
+
+  create(data: Partial<Card>): Promise<Card> {
+    return this.cardRepository.createAndSave(data);
+  }
+
+  update(id: string, data: Partial<Card>): Promise<Card> {
+    return this.cardRepository.createAndSave({ id, ...data });
+  }
+
+  remove(id: string): Promise<void> {
+    return this.cardRepository.remove(id);
+  }
+}

--- a/src/collection/service/inventory.service.spec.ts
+++ b/src/collection/service/inventory.service.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InventoryService } from './inventory.service';
+import { InventoryItemRepository } from '../repository/inventory-item.repository';
+
+describe('InventoryService', () => {
+  let service: InventoryService;
+  let repo: jest.Mocked<InventoryItemRepository>;
+
+  beforeEach(async () => {
+    const repoMock: jest.Mocked<InventoryItemRepository> = {
+      findByUser: jest.fn(),
+      findById: jest.fn(),
+      createAndSave: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InventoryService,
+        { provide: InventoryItemRepository, useValue: repoMock },
+      ],
+    }).compile();
+
+    service = module.get<InventoryService>(InventoryService);
+    repo = module.get(InventoryItemRepository);
+  });
+
+  it('should create an item', async () => {
+    const item: any = { id: '1' };
+    repo.createAndSave.mockResolvedValue(item);
+    const result = await service.create({});
+    expect(result).toBe(item);
+    expect(repo.createAndSave).toHaveBeenCalled();
+  });
+
+  it('should update an item', async () => {
+    const item: any = { id: '1' };
+    repo.update.mockResolvedValue(item);
+    const result = await service.update('1', {});
+    expect(result).toBe(item);
+    expect(repo.update).toHaveBeenCalledWith('1', {});
+  });
+
+  it('should remove an item', async () => {
+    repo.remove.mockResolvedValue(undefined);
+    await service.remove('1');
+    expect(repo.remove).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/collection/service/inventory.service.ts
+++ b/src/collection/service/inventory.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InventoryItemRepository } from '../repository/inventory-item.repository';
+import { InventoryItem } from '../entity/inventory-item.entity';
+
+@Injectable()
+export class InventoryService {
+  constructor(private readonly repository: InventoryItemRepository) {}
+
+  findByUser(userId: string): Promise<InventoryItem[]> {
+    return this.repository.findByUser(userId);
+  }
+
+  findById(id: string): Promise<InventoryItem | null> {
+    return this.repository.findById(id);
+  }
+
+  create(data: Partial<InventoryItem>): Promise<InventoryItem> {
+    return this.repository.createAndSave(data);
+  }
+
+  update(id: string, data: Partial<InventoryItem>): Promise<InventoryItem> {
+    return this.repository.update(id, data);
+  }
+
+  remove(id: string): Promise<void> {
+    return this.repository.remove(id);
+  }
+}

--- a/src/collection/service/wishlist.service.spec.ts
+++ b/src/collection/service/wishlist.service.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WishlistService } from './wishlist.service';
+import { WishlistItemRepository } from '../repository/wishlist-item.repository';
+
+describe('WishlistService', () => {
+  let service: WishlistService;
+  let repo: jest.Mocked<WishlistItemRepository>;
+
+  beforeEach(async () => {
+    const repoMock: jest.Mocked<WishlistItemRepository> = {
+      findByUser: jest.fn(),
+      findById: jest.fn(),
+      createAndSave: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WishlistService,
+        { provide: WishlistItemRepository, useValue: repoMock },
+      ],
+    }).compile();
+
+    service = module.get<WishlistService>(WishlistService);
+    repo = module.get(WishlistItemRepository);
+  });
+
+  it('should create an item', async () => {
+    const item: any = { id: '1' };
+    repo.createAndSave.mockResolvedValue(item);
+    const result = await service.create({});
+    expect(result).toBe(item);
+    expect(repo.createAndSave).toHaveBeenCalled();
+  });
+
+  it('should update an item', async () => {
+    const item: any = { id: '1' };
+    repo.update.mockResolvedValue(item);
+    const result = await service.update('1', {});
+    expect(result).toBe(item);
+    expect(repo.update).toHaveBeenCalledWith('1', {});
+  });
+
+  it('should remove an item', async () => {
+    repo.remove.mockResolvedValue(undefined);
+    await service.remove('1');
+    expect(repo.remove).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/collection/service/wishlist.service.ts
+++ b/src/collection/service/wishlist.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { WishlistItemRepository } from '../repository/wishlist-item.repository';
+import { WishlistItem } from '../entity/wishlist-item.entity';
+
+@Injectable()
+export class WishlistService {
+  constructor(private readonly repository: WishlistItemRepository) {}
+
+  findByUser(userId: string): Promise<WishlistItem[]> {
+    return this.repository.findByUser(userId);
+  }
+
+  findById(id: string): Promise<WishlistItem | null> {
+    return this.repository.findById(id);
+  }
+
+  create(data: Partial<WishlistItem>): Promise<WishlistItem> {
+    return this.repository.createAndSave(data);
+  }
+
+  update(id: string, data: Partial<WishlistItem>): Promise<WishlistItem> {
+    return this.repository.update(id, data);
+  }
+
+  remove(id: string): Promise<void> {
+    return this.repository.remove(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add CollectionModule with entities Card, InventoryItem and WishlistItem
- CRUD services and repositories for cards, inventory and wishlist
- REST controllers InventoryController and WishlistController
- wire CollectionModule into AppModule
- add unit tests for InventoryService and WishlistService

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ef5be3c083209e1f2542c936dbe2