### PR TITLE
Enforce item ownership on update and delete

### DIFF
--- a/src/collection/controller/inventory.controller.ts
+++ b/src/collection/controller/inventory.controller.ts
@@ -30,14 +30,15 @@ export class InventoryController {
 
   @Put(':id')
   update(
+    @Request() req,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: UpdateInventoryItemDto,
   ) {
-    return this.inventoryService.update(id, dto);
+    return this.inventoryService.update(req.user.userId, id, dto);
   }
 
   @Delete(':id')
-  remove(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.inventoryService.remove(id);
+  remove(@Request() req, @Param('id', new ParseUUIDPipe()) id: string) {
+    return this.inventoryService.remove(req.user.userId, id);
   }
 }

--- a/src/collection/controller/wishlist.controller.ts
+++ b/src/collection/controller/wishlist.controller.ts
@@ -30,14 +30,15 @@ export class WishlistController {
 
   @Put(':id')
   update(
+    @Request() req,
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: UpdateWishlistItemDto,
   ) {
-    return this.wishlistService.update(id, dto);
+    return this.wishlistService.update(req.user.userId, id, dto);
   }
 
   @Delete(':id')
-  remove(@Param('id', new ParseUUIDPipe()) id: string) {
-    return this.wishlistService.remove(id);
+  remove(@Request() req, @Param('id', new ParseUUIDPipe()) id: string) {
+    return this.wishlistService.remove(req.user.userId, id);
   }
 }

--- a/src/collection/service/inventory.service.spec.ts
+++ b/src/collection/service/inventory.service.spec.ts
@@ -36,15 +36,19 @@ describe('InventoryService', () => {
 
   it('should update an item', async () => {
     const item: any = { id: '1' };
+    repo.findById.mockResolvedValue({ id: '1', user: { id: 'user1' } } as any);
     repo.update.mockResolvedValue(item);
-    const result = await service.update('1', {});
+    const result = await service.update('user1', '1', {});
     expect(result).toBe(item);
+    expect(repo.findById).toHaveBeenCalledWith('1');
     expect(repo.update).toHaveBeenCalledWith('1', {});
   });
 
   it('should remove an item', async () => {
+    repo.findById.mockResolvedValue({ id: '1', user: { id: 'user1' } } as any);
     repo.remove.mockResolvedValue(undefined);
-    await service.remove('1');
+    await service.remove('user1', '1');
+    expect(repo.findById).toHaveBeenCalledWith('1');
     expect(repo.remove).toHaveBeenCalledWith('1');
   });
 });

--- a/src/collection/service/inventory.service.ts
+++ b/src/collection/service/inventory.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
 import { InventoryItemRepository } from '../repository/inventory-item.repository';
 import { InventoryItem } from '../entity/inventory-item.entity';
 
@@ -18,11 +18,23 @@ export class InventoryService {
     return this.repository.createAndSave(data);
   }
 
-  update(id: string, data: Partial<InventoryItem>): Promise<InventoryItem> {
+  async update(
+    userId: string,
+    id: string,
+    data: Partial<InventoryItem>,
+  ): Promise<InventoryItem> {
+    const item = await this.repository.findById(id);
+    if (!item || item.user.id !== userId) {
+      throw new ForbiddenException();
+    }
     return this.repository.update(id, data);
   }
 
-  remove(id: string): Promise<void> {
+  async remove(userId: string, id: string): Promise<void> {
+    const item = await this.repository.findById(id);
+    if (!item || item.user.id !== userId) {
+      throw new ForbiddenException();
+    }
     return this.repository.remove(id);
   }
 }

--- a/src/collection/service/wishlist.service.spec.ts
+++ b/src/collection/service/wishlist.service.spec.ts
@@ -36,15 +36,19 @@ describe('WishlistService', () => {
 
   it('should update an item', async () => {
     const item: any = { id: '1' };
+    repo.findById.mockResolvedValue({ id: '1', user: { id: 'user1' } } as any);
     repo.update.mockResolvedValue(item);
-    const result = await service.update('1', {});
+    const result = await service.update('user1', '1', {});
     expect(result).toBe(item);
+    expect(repo.findById).toHaveBeenCalledWith('1');
     expect(repo.update).toHaveBeenCalledWith('1', {});
   });
 
   it('should remove an item', async () => {
+    repo.findById.mockResolvedValue({ id: '1', user: { id: 'user1' } } as any);
     repo.remove.mockResolvedValue(undefined);
-    await service.remove('1');
+    await service.remove('user1', '1');
+    expect(repo.findById).toHaveBeenCalledWith('1');
     expect(repo.remove).toHaveBeenCalledWith('1');
   });
 });

--- a/src/collection/service/wishlist.service.ts
+++ b/src/collection/service/wishlist.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
 import { WishlistItemRepository } from '../repository/wishlist-item.repository';
 import { WishlistItem } from '../entity/wishlist-item.entity';
 
@@ -18,11 +18,23 @@ export class WishlistService {
     return this.repository.createAndSave(data);
   }
 
-  update(id: string, data: Partial<WishlistItem>): Promise<WishlistItem> {
+  async update(
+    userId: string,
+    id: string,
+    data: Partial<WishlistItem>,
+  ): Promise<WishlistItem> {
+    const item = await this.repository.findById(id);
+    if (!item || item.user.id !== userId) {
+      throw new ForbiddenException();
+    }
     return this.repository.update(id, data);
   }
 
-  remove(id: string): Promise<void> {
+  async remove(userId: string, id: string): Promise<void> {
+    const item = await this.repository.findById(id);
+    if (!item || item.user.id !== userId) {
+      throw new ForbiddenException();
+    }
     return this.repository.remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- ensure inventory and wishlist items belong to the requesting user before updating or removing them
- pass user information in controllers
- update service tests to reflect new behaviour

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684852e137ec83208cece1a6d1a6ca45