### PR TITLE
Handle missing card on inventory create

### DIFF
--- a/src/collection/service/inventory.service.spec.ts
+++ b/src/collection/service/inventory.service.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { InventoryService } from './inventory.service';
 import { InventoryItemRepository } from '../repository/inventory-item.repository';
+import { CardService } from './card.service';
 
 describe('InventoryService', () => {
   let service: InventoryService;
   let repo: jest.Mocked<InventoryItemRepository>;
+  let card: jest.Mocked<CardService>;
 
   beforeEach(async () => {
     const repoMock: jest.Mocked<InventoryItemRepository> = {
@@ -15,23 +17,33 @@ describe('InventoryService', () => {
       remove: jest.fn(),
     } as any;
 
+    const cardMock: jest.Mocked<CardService> = {
+      findById: jest.fn(),
+      create: jest.fn(),
+    } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         InventoryService,
         { provide: InventoryItemRepository, useValue: repoMock },
+        { provide: CardService, useValue: cardMock },
       ],
     }).compile();
 
     service = module.get<InventoryService>(InventoryService);
     repo = module.get(InventoryItemRepository);
+    card = module.get(CardService);
   });
 
   it('should create an item', async () => {
     const item: any = { id: '1' };
     repo.createAndSave.mockResolvedValue(item);
-    const result = await service.create({});
+    card.findById.mockResolvedValue(null);
+    const result = await service.create({ card: { id: 'card1' } } as any);
     expect(result).toBe(item);
     expect(repo.createAndSave).toHaveBeenCalled();
+    expect(card.findById).toHaveBeenCalledWith('card1');
+    expect(card.create).toHaveBeenCalled();
   });
 
   it('should update an item', async () => {

--- a/src/collection/service/inventory.service.ts
+++ b/src/collection/service/inventory.service.ts
@@ -1,10 +1,14 @@
 import { Injectable, ForbiddenException } from '@nestjs/common';
 import { InventoryItemRepository } from '../repository/inventory-item.repository';
 import { InventoryItem } from '../entity/inventory-item.entity';
+import { CardService } from './card.service';
 
 @Injectable()
 export class InventoryService {
-  constructor(private readonly repository: InventoryItemRepository) {}
+  constructor(
+    private readonly repository: InventoryItemRepository,
+    private readonly cardService: CardService,
+  ) {}
 
   findByUser(userId: string): Promise<InventoryItem[]> {
     return this.repository.findByUser(userId);
@@ -14,7 +18,13 @@ export class InventoryService {
     return this.repository.findById(id);
   }
 
-  create(data: Partial<InventoryItem>): Promise<InventoryItem> {
+  async create(data: Partial<InventoryItem>): Promise<InventoryItem> {
+    if (data.card) {
+      const existing = await this.cardService.findById(data.card.id);
+      if (!existing) {
+        await this.cardService.create(data.card as any);
+      }
+    }
     return this.repository.createAndSave(data);
   }
 


### PR DESCRIPTION
## Summary
- check if card exists before creating inventory item
- auto-create card if missing
- update inventory service unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488af9b158832090773da88890be67