### PR TITLE
Move profile endpoints to new module

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from 'src/app.service';
 import { UserModule } from './user/user.module';
 import { CardModule } from './card/card.module';
 import { CollectionModule } from './collection/collection.module';
+import { ProfileModule } from './me/profile/profile.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { CollectionModule } from './collection/collection.module';
     AuthModule,
     CardModule,
     CollectionModule,
+    ProfileModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/me/profile/controller/profile.controller.ts
+++ b/apps/backend/src/me/profile/controller/profile.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Get,
+  Post,
+  UseGuards,
+  Request,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { v4 as uuid } from 'uuid';
+import { UserService } from 'src/user/service/user.service';
+import { GetUserProfileResponse } from 'src/user/controller/response/get-user-profile.response';
+
+@UseGuards(AuthGuard('jwt'))
+@Controller('me/profile')
+export class ProfileController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get()
+  async getProfile(@Request() req): Promise<GetUserProfileResponse> {
+    const userId = req.user.userId;
+    const user = await this.userService.findById(userId);
+    return GetUserProfileResponse.create(user);
+  }
+
+  @Post('upload-avatar')
+  @UseInterceptors(
+    FileInterceptor('avatar', {
+      storage: diskStorage({
+        destination: './uploads/avatars',
+        filename: (req, file, cb) => {
+          const ext = file.originalname.split('.').pop();
+          const filename = `${uuid()}.${ext}`;
+          cb(null, filename);
+        },
+      }),
+    }),
+  )
+  uploadAvatar(@UploadedFile() file: Express.Multer.File) {
+    return { url: `/uploads/avatars/${file.filename}` };
+  }
+}

--- a/apps/backend/src/me/profile/profile.module.ts
+++ b/apps/backend/src/me/profile/profile.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProfileController } from './controller/profile.controller';
+import { UserModule } from 'src/user/user.module';
+
+@Module({
+  imports: [UserModule],
+  controllers: [ProfileController],
+})
+export class ProfileModule {}

--- a/apps/backend/src/user/controller/user.controller.ts
+++ b/apps/backend/src/user/controller/user.controller.ts
@@ -4,9 +4,6 @@ import {
   Get,
   Body,
   UseGuards,
-  Request,
-  UploadedFile,
-  UseInterceptors,
   Delete,
   Param,
   ParseUUIDPipe,
@@ -17,10 +14,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { Roles } from 'src/auth/roles.decorator';
 import { RolesGuard } from 'src/auth/roles.guard';
 import { Role } from '../entity/user.entity';
-import { GetUserProfileResponse } from './response/get-user-profile.response';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { diskStorage } from 'multer';
-import { v4 as uuid } from 'uuid';
+
 
 @Controller('users')
 export class UserController {
@@ -31,35 +25,12 @@ export class UserController {
     return this.userService.create(createUserDto);
   }
 
-  @Post('upload-avatar')
-  @UseInterceptors(
-    FileInterceptor('avatar', {
-      storage: diskStorage({
-        destination: './uploads/avatars',
-        filename: (req, file, cb) => {
-          const ext = file.originalname.split('.').pop();
-          const filename = `${uuid()}.${ext}`;
-          cb(null, filename);
-        },
-      }),
-    }),
-  )
-  uploadAvatar(@UploadedFile() file: Express.Multer.File) {
-    return { url: `/uploads/avatars/${file.filename}` };
-  }
 
   @Get()
   findAll() {
     return this.userService.findAll();
   }
 
-  @UseGuards(AuthGuard('jwt'))
-  @Get('me')
-  async getProfile(@Request() req): Promise<GetUserProfileResponse> {
-    const userId = req.user.userId;
-    const user = await this.userService.findById(userId);
-    return GetUserProfileResponse.create(user);
-  }
 
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(Role.ADMIN)


### PR DESCRIPTION
## Summary
- implement `ProfileModule` and `ProfileController`
- add profile module to application module
- remove avatar upload and profile endpoints from `UserController`

## Testing
- `npm --prefix apps/backend run lint` *(fails: ESLint config missing)*
- `npm --prefix apps/backend run build` *(fails: nest not found)*
- `npm --prefix apps/backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4eb3a1308320bb71d57749aaf6dc