### PR TITLE
Update README to reference trade-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 Este repositorio contiene los proyectos de **frontend** y **backend** para Magic Friendly Trade. Cada uno de ellos se encuentra dentro del directorio `apps`.
 
 - `apps/backend`: aplicación NestJS existente.
-- `apps/frontend`: futura aplicación de cliente.
+- `apps/trade-web`: cliente actual construido con React y Vite.
 
 Para trabajar con cada proyecto, ejecuta los comandos de npm dentro de su carpeta o utiliza los **workspaces** definidos en el `package.json` raíz.


### PR DESCRIPTION
## Summary
- reference `apps/trade-web` in README
- note that it's the current React+Vite client

## Testing
- `npm test --workspace=apps/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f27c06abc8320b9ee2bc67c28a0bb