### PR TITLE
Auto login after verifying email

### DIFF
--- a/apps/backend/src/auth/controller/auth.controller.ts
+++ b/apps/backend/src/auth/controller/auth.controller.ts
@@ -29,10 +29,13 @@ export class AuthController {
       throw new BadRequestException('Token no proporcionado');
     }
 
-    await this.authService.verifyEmailToken(token);
-    
+    const user = await this.authService.verifyEmailToken(token);
+    const { access_token } = await this.authService.login(user);
+
     return {
-      url: this.configService.get('FRONTEND_URL') + '/auth/login?verified=true',
+      url:
+        this.configService.get('FRONTEND_URL') +
+        `/dashboard?token=${access_token}`,
     };
   }
 }

--- a/apps/backend/src/auth/service/auth.service.ts
+++ b/apps/backend/src/auth/service/auth.service.ts
@@ -44,14 +44,12 @@ export class AuthService {
         throw new BadRequestException('Usuario no encontrado');
       }
 
-      if (user.isEmailVerified) {
-        return { message: 'El correo ya ha sido verificado.' };
+      if (!user.isEmailVerified) {
+        user.isEmailVerified = true;
+        await this.userRepository.save(user);
       }
 
-      user.isEmailVerified = true;
-      await this.userRepository.save(user);
-
-      return { message: 'Correo verificado correctamente' };
+      return user;
     } catch (error) {
       throw new BadRequestException('Token inválido o expirado');
     }

--- a/apps/trade-web/src/App.tsx
+++ b/apps/trade-web/src/App.tsx
@@ -1,14 +1,30 @@
-import { useState } from 'react'
-import { Container, Typography } from '@mui/material'
+import { useEffect, useState } from 'react'
+import { Container } from '@mui/material'
 import './App.css'
 import { Login, type AuthUser } from './Login'
+import Dashboard from './Dashboard'
 
 function App() {
   const [user, userSet] = useState<AuthUser | null>(null)
 
+  useEffect(() => {
+    if (!user) {
+      const params = new URLSearchParams(window.location.search)
+      const token = params.get('token')
+      if (token) {
+        userSet({ access_token: token })
+        params.delete('token')
+        const url = window.location.pathname
+        const newSearch = params.toString()
+        const newUrl = newSearch ? `${url}?${newSearch}` : url
+        window.history.replaceState({}, '', newUrl)
+      }
+    }
+  }, [user])
+
   return (
     <Container>
-      {user && <Typography>{JSON.stringify(user)}</Typography>}
+      {user && <Dashboard user={user} />}
       {!user && <Login onUserLogin={(user) => { userSet(user) }} />}
     </Container>
   )

--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -1,0 +1,13 @@
+import { Typography, Container } from '@mui/material'
+import { AuthUser } from './Login'
+
+export default function Dashboard({ user }: { user: AuthUser }) {
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>
+        Dashboard
+      </Typography>
+      <Typography>Your token: {user.access_token}</Typography>
+    </Container>
+  )
+}


### PR DESCRIPTION
## Summary
- redirect to dashboard with token after email verification
- adjust auth service to return user
- parse token on web dashboard
- show a minimal dashboard once logged in

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` in trade-web *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a27440083208d3d04d2f3c1f964