### PR TITLE
Fix login redirect logic

### DIFF
--- a/apps/trade-web/src/App.tsx
+++ b/apps/trade-web/src/App.tsx
@@ -1,31 +1,63 @@
 import { useEffect, useState } from 'react'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { Container } from '@mui/material'
 import './App.css'
 import { Login, type AuthUser } from './Login'
 import Dashboard from './Dashboard'
 
 function App() {
-  const [user, userSet] = useState<AuthUser | null>(null)
+  const [user, userSet] = useState<AuthUser | null>(() => {
+    const stored = localStorage.getItem('token')
+    return stored ? { access_token: stored } : null
+  })
 
   useEffect(() => {
-    if (!user) {
-      const params = new URLSearchParams(window.location.search)
-      const token = params.get('token')
-      if (token) {
-        userSet({ access_token: token })
-        params.delete('token')
-        const url = window.location.pathname
-        const newSearch = params.toString()
-        const newUrl = newSearch ? `${url}?${newSearch}` : url
-        window.history.replaceState({}, '', newUrl)
-      }
+    const params = new URLSearchParams(window.location.search)
+    const token = params.get('token')
+    if (token) {
+      userSet({ access_token: token })
+      params.delete('token')
+      const url = window.location.pathname
+      const newSearch = params.toString()
+      const newUrl = newSearch ? `${url}?${newSearch}` : url
+      window.history.replaceState({}, '', newUrl)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem('token', user.access_token)
+    } else {
+      localStorage.removeItem('token')
     }
   }, [user])
 
   return (
     <Container>
-      {user && <Dashboard user={user} />}
-      {!user && <Login onUserLogin={(user) => { userSet(user) }} />}
+      <BrowserRouter>
+        <Routes>
+          <Route
+            path="/login"
+            element={
+              !user ? (
+                <Login onUserLogin={(u) => userSet(u)} />
+              ) : (
+                <Navigate to="/dashboard" replace />
+              )
+            }
+          />
+          <Route
+            path="/dashboard"
+            element={
+              user ? <Dashboard user={user} /> : <Navigate to="/login" replace />
+            }
+          />
+          <Route
+            path="/"
+            element={<Navigate to={user ? '/dashboard' : '/login'} replace />}
+          />
+        </Routes>
+      </BrowserRouter>
     </Container>
   )
 }


### PR DESCRIPTION
## Summary
- persist token in `localStorage`
- add routing with `react-router-dom`
- redirect to login when not authenticated and to dashboard when logged in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f3425dfd88320980737ca17373223