### PR TITLE
Add react-router-dom dependency

### DIFF
--- a/apps/trade-web/package.json
+++ b/apps/trade-web/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",
+    "react-router-dom": "^7.6.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.15.11"


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency to trade-web package

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4d76633c8320b8bb98993026ddda