### PR TITLE
Fix dashboard layout and hamburger animation

### DIFF
--- a/apps/trade-web/src/Dashboard.css
+++ b/apps/trade-web/src/Dashboard.css
@@ -1,0 +1,28 @@
+.hamburger {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+}
+
+.hamburger-line {
+  width: 20px;
+  height: 2px;
+  background-color: currentColor;
+  margin: 3px 0;
+  transition: transform 0.3s, opacity 0.3s;
+}
+
+.hamburger.open .line1 {
+  transform: translateY(5px) rotate(45deg);
+}
+
+.hamburger.open .line2 {
+  opacity: 0;
+}
+
+.hamburger.open .line3 {
+  transform: translateY(-5px) rotate(-45deg);
+}

--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -12,8 +12,8 @@ import {
   ListItemText,
   Box,
 } from "@mui/material";
-import MenuIcon from "@mui/icons-material/Menu";
 import type { AuthUser } from "./Login";
+import "./Dashboard.css";
 
 type DashboardProps = {
   user: AuthUser;
@@ -29,7 +29,7 @@ export const Dashboard = ({ user }: DashboardProps) => {
   ];
 
   return (
-    <Box>
+    <Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
       <AppBar position="static">
         <Toolbar>
           <IconButton
@@ -38,8 +38,11 @@ export const Dashboard = ({ user }: DashboardProps) => {
             aria-label="menu"
             sx={{ mr: 2 }}
             onClick={() => setOpen(true)}
+            className={open ? "hamburger open" : "hamburger"}
           >
-            <MenuIcon />
+            <span className="hamburger-line line1" />
+            <span className="hamburger-line line2" />
+            <span className="hamburger-line line3" />
           </IconButton>
           <Typography variant="h6" component="div">
             Dashboard
@@ -59,7 +62,7 @@ export const Dashboard = ({ user }: DashboardProps) => {
           </List>
         </Box>
       </Drawer>
-      <Container sx={{ mt: 2 }}>
+      <Container sx={{ mt: 2, flexGrow: 1 }}>
         <Typography variant="h4" gutterBottom>
           Dashboard
         </Typography>

--- a/apps/trade-web/src/index.css
+++ b/apps/trade-web/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- keep the `AppBar` fixed at the top by removing centering rules on `body`
- structure `Dashboard` with a flex column layout
- add a hamburger icon animation for drawer open/close

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68501b611a548320852eeddae29bb0b8