### PR TITLE
Fix navigation width

### DIFF
--- a/apps/trade-web/src/App.css
+++ b/apps/trade-web/src/App.css
@@ -1,5 +1,5 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- set root container to full width

## Testing
- `npm --workspaces run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68501e54ba7c8320a0dff7592388b6f3