### PR TITLE
Improve hamburger toggle

### DIFF
--- a/apps/trade-web/src/Dashboard.css
+++ b/apps/trade-web/src/Dashboard.css
@@ -20,7 +20,7 @@
 .hamburger-line {
   width: 20px;
   height: 2px;
-  background-color: currentColor;
+  background-color: #f0f0f0;
   margin: 3px 0;
   transition: transform 0.3s, opacity 0.3s;
 }

--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -37,7 +37,7 @@ export const Dashboard = ({ user }: DashboardProps) => {
             color="inherit"
             aria-label="menu"
             sx={{ mr: 2 }}
-            onClick={() => setOpen(true)}
+            onClick={() => setOpen(!open)}
             className={open ? "hamburger open" : "hamburger"}
           >
             <span className="hamburger-line line1" />


### PR DESCRIPTION
## Summary
- toggle the hamburger menu instead of only opening
- make hamburger lines light for better contrast

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685021a5552c8320a632caab1f0d9edd