### PR TITLE
Fix hamburger CSS to enable dimensions

### DIFF
--- a/apps/trade-web/src/Dashboard.css
+++ b/apps/trade-web/src/Dashboard.css
@@ -18,6 +18,7 @@
 }
 
 .hamburger-line {
+  display: block;
   width: 20px;
   height: 2px;
   background-color: #f0f0f0;


### PR DESCRIPTION
## Summary
- enable width/height on `.hamburger-line` by adding `display: block`

## Testing
- `npm --workspace apps/trade-web run lint` *(fails: cannot find module `@eslint/js`)*
- `npm --workspace apps/backend run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685078cb3e5c832085e8ab660f91c3f4