### PR TITLE
Fix icon button styles

### DIFF
--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -35,7 +35,7 @@ export const Dashboard = ({ user }: DashboardProps) => {
           <IconButton
             edge="start"
             aria-label="menu"
-            sx={{ mr: 2 }}
+            sx={{ mr: 2, borderRadius: 1, width: 32, height: 32, border: "1px solid", color: "whitesmoke", p: 0.5 }}
             onClick={() => setOpen(!open)}
             className={open ? "hamburger open" : "hamburger"}
           >


### PR DESCRIPTION
## Summary
- adjust the menu `IconButton` styles so size, border and colors override theme

## Testing
- `npm --workspace apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68507958871c8320b2059ab2dac18b10