### PR TITLE
Add user profile menu

### DIFF
--- a/apps/trade-web/src/App.tsx
+++ b/apps/trade-web/src/App.tsx
@@ -11,6 +11,10 @@ function App() {
     return stored ? { access_token: stored } : null
   })
 
+  const handleLogout = () => {
+    userSet(null)
+  }
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const token = params.get('token')
@@ -49,7 +53,11 @@ function App() {
           <Route
             path="/dashboard"
             element={
-              user ? <Dashboard user={user} /> : <Navigate to="/login" replace />
+              user ? (
+                <Dashboard user={user} onLogout={handleLogout} />
+              ) : (
+                <Navigate to="/login" replace />
+              )
             }
           />
           <Route

--- a/apps/trade-web/src/Dashboard.css
+++ b/apps/trade-web/src/Dashboard.css
@@ -37,3 +37,7 @@
 .hamburger.open .line3 {
   transform: translateY(-5px) rotate(-45deg);
 }
+
+.user-menu-button {
+  cursor: pointer;
+}

--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -1,10 +1,14 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Typography,
   Container,
   AppBar,
   Toolbar,
   IconButton,
+  Avatar,
+  Menu,
+  MenuItem,
   Drawer,
   List,
   ListItem,
@@ -13,14 +17,40 @@ import {
   Box,
 } from "@mui/material";
 import type { AuthUser } from "./Login";
+import { getProfile } from "./api";
 import "./Dashboard.css";
 
 type DashboardProps = {
   user: AuthUser;
+  onLogout: () => void;
 };
 
-export const Dashboard = ({ user }: DashboardProps) => {
+type UserProfile = {
+  firstName: string;
+  lastName: string;
+  username: string;
+  avatar?: string;
+};
+
+export const Dashboard = ({ user, onLogout }: DashboardProps) => {
   const [open, setOpen] = useState(false);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getProfile(user.access_token)
+      .then(setProfile)
+      .catch((err) => console.warn(err));
+  }, [user.access_token]);
+
+  const handleMenuOpen = (e: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
 
   const menuItems = [
     "Inventario",
@@ -46,6 +76,22 @@ export const Dashboard = ({ user }: DashboardProps) => {
           <Typography variant="h6" component="div">
             Dashboard
           </Typography>
+          <Box sx={{ ml: "auto", display: "flex", alignItems: "center" }} onClick={handleMenuOpen} className="user-menu-button">
+            <Avatar src={profile?.avatar} sx={{ width: 32, height: 32, mr: 1 }} />
+            <Typography>{profile?.firstName || profile?.username}</Typography>
+          </Box>
+          <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
+            <MenuItem onClick={handleMenuClose}>Perfil</MenuItem>
+            <MenuItem
+              onClick={() => {
+                handleMenuClose();
+                onLogout();
+                navigate('/login', { replace: true });
+              }}
+            >
+              Cerrar sesión
+            </MenuItem>
+          </Menu>
         </Toolbar>
       </AppBar>
       <Drawer

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -12,6 +12,21 @@ function jsonFetch( input: string | URL | globalThis.Request, init?: RequestInit
     })
 
 }
+
+export async function getProfile(token: string) {
+  const response = await fetch(API_URL + "/me/profile", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch profile');
+  }
+
+  return await response.json();
+}
 export async function login(email: string, password: string) {
   const response = await jsonFetch(API_URL + "/auth/login", {
     method: "POST",


### PR DESCRIPTION
## Summary
- add function to fetch authenticated profile
- display profile info in dashboard with avatar menu
- allow logout from dashboard
- wire logout handler from App
- minor styling for avatar button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68508efb9f548320b0ff248b18bcf457