### PR TITLE
feat(web): add login background and links

### DIFF
--- a/apps/trade-web/src/Login.tsx
+++ b/apps/trade-web/src/Login.tsx
@@ -7,7 +7,10 @@ import {
   TextField,
   Typography,
   Box,
+  Link,
 } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import FondoLogin from "./images/FondoLogin.png";
 import "./App.css";
 import { login } from "./api";
 
@@ -43,6 +46,9 @@ export const Login = ({ onUserLogin }: LoginProps) => {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
+        backgroundImage: `url(${FondoLogin})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
       }}
     >
       <Typography variant="h4" component="h1" gutterBottom>
@@ -77,6 +83,12 @@ export const Login = ({ onUserLogin }: LoginProps) => {
             >
               Continue
             </Button>
+            <Box display="flex" justifyContent="space-between">
+              <Link component={RouterLink} to="/forgot-password">
+                He olvidado la contraseña
+              </Link>
+              <Link component={RouterLink} to="/register">Registrarme</Link>
+            </Box>
           </Box>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- enhance `Login` page with background image
- include password reset and registration links

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850ac2102f883209458ebab7b7aa9d5