### PR TITLE
Add logo to login page

### DIFF
--- a/apps/trade-web/src/Login.tsx
+++ b/apps/trade-web/src/Login.tsx
@@ -8,6 +8,7 @@ import {
 } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 import FondoLogin from "./images/FondoLogin.png";
+import Logo from "./images/Logo.png";
 import "./App.css";
 import { login } from "./api";
 
@@ -63,9 +64,9 @@ export const Login = ({ onUserLogin }: LoginProps) => {
       >
         <Box sx={{ width: 280, mx: "auto", p: 3 }}>
           <Box display="flex" flexDirection="column" gap={2} width="100%">
-            <Typography variant="h5" align="center">
-              Login
-            </Typography>
+            <Box textAlign="center">
+              <img src={Logo} alt="Magic Friendly Trade logo" style={{ maxWidth: "200px", width: "100%" }} />
+            </Box>
             <TextField
               label="Email"
               type="email"


### PR DESCRIPTION
## Summary
- show Magic Friendly Trade logo on the login page

## Testing
- `npm -w apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm -w apps/trade-web run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68515c484f448320b3a61ed99a6b5ba7