### PR TITLE
Add registration page with API call

### DIFF
--- a/apps/trade-web/src/App.tsx
+++ b/apps/trade-web/src/App.tsx
@@ -3,7 +3,8 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { Container } from '@mui/material'
 import './App.css'
 import { Login, type AuthUser } from './Login'
-import {Dashboard} from './Dashboard'
+import { Dashboard } from './Dashboard'
+import Register from './Register'
 
 function App() {
   const [user, userSet] = useState<AuthUser | null>(() => {
@@ -48,6 +49,12 @@ function App() {
               ) : (
                 <Navigate to="/dashboard" replace />
               )
+            }
+          />
+          <Route
+            path="/register"
+            element={
+              !user ? <Register /> : <Navigate to="/dashboard" replace />
             }
           />
           <Route

--- a/apps/trade-web/src/Register.tsx
+++ b/apps/trade-web/src/Register.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
+import RegistroImg from "./images/Registro.png";
+import Logo from "./images/Logo.png";
+import "./App.css";
+import { registerUser } from "./api";
+
+export const Register = () => {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+
+  const navigate = useNavigate();
+
+  const disabled = !username || !email || !password || !firstName || !lastName;
+
+  async function handleRegister() {
+    setError("");
+    try {
+      await registerUser({ username, email, password, firstName, lastName });
+      setMessage("Te enviamos un correo para verificar tu cuenta");
+      setTimeout(() => navigate("/login"), 500);
+    } catch (ex) {
+      console.warn(ex);
+      setError("Registro fallido");
+    }
+  }
+
+  return (
+    <Box
+      sx={{ minHeight: "100vh", width: "100%", display: "flex" }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          backgroundImage: `url(${RegistroImg})`,
+          backgroundSize: "cover",
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "center",
+        }}
+      />
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          bgcolor: "background.default",
+        }}
+      >
+        <Box sx={{ width: 280, mx: "auto", p: 3 }}>
+          <Box display="flex" flexDirection="column" gap={2} width="100%">
+            <Box textAlign="center">
+              <img src={Logo} alt="Magic Friendly Trade logo" style={{ maxWidth: "200px", width: "100%" }} />
+            </Box>
+            <TextField
+              label="Nombre de usuario"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value.toLowerCase())}
+              fullWidth
+            />
+            <TextField
+              label="Contraseña"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Nombre"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Apellido"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              fullWidth
+            />
+            {error && (
+              <Typography color="error" variant="body2">
+                {error}
+              </Typography>
+            )}
+            {message && (
+              <Typography color="primary" variant="body2">
+                {message}
+              </Typography>
+            )}
+            <Box display="flex" justifyContent="space-between" mt={1}>
+              <Button component={RouterLink} to="/login" variant="outlined">
+                Atrás
+              </Button>
+              <Button variant="contained" onClick={handleRegister} disabled={disabled}>
+                Registrarme
+              </Button>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default Register;

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -43,6 +43,29 @@ export async function login(email: string, password: string) {
 
 }
 
+export type CreateUserDto = {
+  username: string;
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+};
+
+export async function registerUser(user: CreateUserDto) {
+  const response = await jsonFetch(API_URL + "/users", {
+    method: "POST",
+    payload: user,
+  });
+
+  const data = await response.json();
+
+  if (response.status !== 201) {
+    throw Error(Array.isArray(data.message) ? data.message.join(", ") : data.message);
+  }
+
+  return data;
+}
+
 export function authApi(token: string) {
   return {
     async me(token: string) {


### PR DESCRIPTION
## Summary
- create `Register` component mirroring Login layout
- extend API helpers with `registerUser`
- add `/register` route to app

## Testing
- `npm --workspace apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --workspace apps/trade-web run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68516668bae083209d6fb7081fecc61b