### PR TITLE
Add login link in register page

### DIFF
--- a/apps/trade-web/src/Register.tsx
+++ b/apps/trade-web/src/Register.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   TextField,
   Typography,
+  Link,
 } from "@mui/material";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import RegistroImg from "./images/Registro.png";
@@ -106,9 +107,9 @@ export const Register = () => {
               </Typography>
             )}
             <Box display="flex" justifyContent="space-between" mt={1}>
-              <Button component={RouterLink} to="/login" variant="outlined">
+              <Link component={RouterLink} to="/login" sx={{ fontSize: "0.8rem" }}>
                 Atrás
-              </Button>
+              </Link>
               <Button variant="contained" onClick={handleRegister} disabled={disabled}>
                 Registrarme
               </Button>


### PR DESCRIPTION
## Summary
- add missing Link import and replace Back button with a link

## Testing
- `npm --workspace=apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --workspace=apps/backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516809a19883209c1353e0325fc6d6