### PR TITLE
Add card search UI on dashboard

### DIFF
--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -13,9 +13,12 @@ import {
   ListItemButton,
   ListItemText,
   Box,
+  TextField,
+  InputAdornment,
 } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
 import type { AuthUser } from "./Login";
-import { getProfile } from "./api";
+import { getProfile, searchCards } from "./api";
 import "./Dashboard.css";
 
 type DashboardProps = {
@@ -34,6 +37,8 @@ export const Dashboard = ({ user, onLogout }: DashboardProps) => {
   const [open, setOpen] = useState(false);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [profileDrawerOpen, setProfileDrawerOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<any[]>([]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -44,6 +49,16 @@ export const Dashboard = ({ user, onLogout }: DashboardProps) => {
 
   const handleProfileDrawerClose = () => {
     setProfileDrawerOpen(false);
+  };
+
+  const handleSearch = async () => {
+    if (!query.trim()) return;
+    try {
+      const data = await searchCards(query.trim());
+      setResults(data.data || []);
+    } catch (err) {
+      console.warn(err);
+    }
   };
 
   const menuItems = [
@@ -127,10 +142,43 @@ export const Dashboard = ({ user, onLogout }: DashboardProps) => {
         </Box>
       </Drawer>
       <Container sx={{ mt: 2, flexGrow: 1 }}>
-        <Typography variant="h4" gutterBottom>
-          Dashboard
-        </Typography>
-        <Typography>Your token: {user.access_token}</Typography>
+        <Box display="flex" justifyContent="center" mb={2}>
+          <TextField
+            placeholder="Search cards"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleSearch();
+              }
+            }}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton onClick={handleSearch} edge="end">
+                    <SearchIcon />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            sx={{ maxWidth: 400, width: '100%' }}
+          />
+        </Box>
+        <Box>
+          {results.map((card) => (
+            <Box
+              key={card.id}
+              sx={{ mb: 1, p: 1, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}
+            >
+              <Typography>{card.name}</Typography>
+              {card.set_name && (
+                <Typography variant="caption" color="text.secondary">
+                  {card.set_name}
+                </Typography>
+              )}
+            </Box>
+          ))}
+        </Box>
       </Container>
     </Box>
   );

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -75,6 +75,18 @@ export async function registerUser(data: {
   return await response.json();
 }
 
+export async function searchCards(query: string) {
+  const response = await fetch(
+    `${API_URL}/cards/search?q=${encodeURIComponent(query)}`,
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to search cards');
+  }
+
+  return await response.json();
+}
+
 export function authApi(token: string) {
   return {
     async me(token: string) {


### PR DESCRIPTION
## Summary
- add searchCards API client
- show search bar in Dashboard with Enter or button to submit
- display card search results

## Testing
- `npm --workspace apps/trade-web run lint` *(fails: cannot find package '@eslint/js')*
- `npm --workspace apps/trade-web run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68517ab83e5c8320b05073f3866eeab1