### PR TITLE
Add BACKEND_URL support

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,22 @@
+# Backend environment configuration
+BACKEND_URL=http://localhost:3000
+FRONTEND_URL=http://localhost:5173
+
+# JWT settings
+JWT_SECRET=changeme
+JWT_EXPIRES_IN=3600s
+
+# Database settings
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=dbuser
+DB_PASSWORD=dbpass
+DB_NAME=magictrade
+
+# Email settings
+EMAIL_SMTP_HOST=smtp.example.com
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_USER=user@example.com
+EMAIL_SMTP_PASS=password
+EMAIL_FROM_NAME=Magic Trade
+EMAIL_FROM_ADDRESS=no-reply@example.com

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -32,6 +32,10 @@
 $ npm install
 ```
 
+### Environment Variables
+
+Configura un archivo `.env` en este directorio basándote en el archivo `.env.example` incluido. Asegúrte de definir `BACKEND_URL` con la URL pública donde se desplegará el backend.
+
 ## Running the app
 
 ```bash

--- a/apps/backend/src/auth/controller/auth.controller.ts
+++ b/apps/backend/src/auth/controller/auth.controller.ts
@@ -29,13 +29,10 @@ export class AuthController {
       throw new BadRequestException('Token no proporcionado');
     }
 
-    const user = await this.authService.verifyEmailToken(token);
-    const { access_token } = await this.authService.login(user);
+    await this.authService.verifyEmailToken(token);
 
     return {
-      url:
-        this.configService.get('FRONTEND_URL') +
-        `/dashboard?token=${access_token}`,
+      url: this.configService.get('FRONTEND_URL') + '/login',
     };
   }
 }

--- a/apps/backend/src/user/service/user.service.ts
+++ b/apps/backend/src/user/service/user.service.ts
@@ -47,8 +47,8 @@ export class UserService {
         expiresIn: '1h',
       },
     );
-    const frontendUrl = this.configService.get('FRONTEND_URL');
-    const verificationLink = `${frontendUrl}/auth/verify-email?token=${token}`;
+    const backendUrl = this.configService.get('BACKEND_URL');
+    const verificationLink = `${backendUrl}/auth/verify-email?token=${token}`;
 
     await this.mailService.sendMail({
       to: user.email,


### PR DESCRIPTION
## Summary
- introduce `BACKEND_URL` in backend `.env.example`
- document the new variable in backend README
- use `BACKEND_URL` when sending email verification links
- redirect email verification to login page

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547cc441808320bf59b48c9e9fb947