### PR TITLE
Show confirmation email in login popup

### DIFF
--- a/apps/trade-web/src/Login.tsx
+++ b/apps/trade-web/src/Login.tsx
@@ -30,12 +30,17 @@ export const Login = ({ onUserLogin }: LoginProps) => {
   const [password, passwordSet] = useState("");
   const [error, errorSet] = useState("");
   const [showVerifyPopup, setShowVerifyPopup] = useState(false);
+  const [verifyEmailAddress, setVerifyEmailAddress] = useState("");
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     if (params.get("verifyEmail") === "1") {
       setShowVerifyPopup(true);
+      if (params.get("email")) {
+        setVerifyEmailAddress(params.get("email") || "");
+      }
       params.delete("verifyEmail");
+      params.delete("email");
       const url = location.pathname;
       const newSearch = params.toString();
       const newUrl = newSearch ? `${url}?${newSearch}` : url;
@@ -129,7 +134,7 @@ export const Login = ({ onUserLogin }: LoginProps) => {
         <DialogTitle>Verifica tu correo</DialogTitle>
         <DialogContent>
           <Typography>
-            Te hemos enviado un correo de confirmación. Revisa tu bandeja de entrada para activar tu cuenta.
+            Te hemos enviado un correo de confirmación a {verifyEmailAddress}. Revisa tu bandeja de entrada para activar tu cuenta.
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/apps/trade-web/src/Register.tsx
+++ b/apps/trade-web/src/Register.tsx
@@ -45,7 +45,13 @@ export const Register = () => {
     }
     try {
       await registerUser({ username, email, password, firstName, lastName });
-      setTimeout(() => navigate("/login?verifyEmail=1"), 500);
+      setTimeout(
+        () =>
+          navigate(
+            `/login?verifyEmail=1&email=${encodeURIComponent(email)}`,
+          ),
+        500,
+      );
     } catch (ex) {
       console.warn(ex);
       setError("Registro fallido");


### PR DESCRIPTION
## Summary
- display the address used to register in the login verification popup
- pass email parameter when redirecting after registration

## Testing
- `npm --workspace=apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --workspace=apps/trade-web run build` *(fails: Cannot find module 'react')*
- `npm --workspace=apps/backend test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854921a462c8320a5fc60f9074695bb