### PR TITLE
Fix card search image size

### DIFF
--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -189,8 +189,8 @@ export const Dashboard = ({ user, onLogout }: DashboardProps) => {
         >
           {results.map((card) => {
             const imgSrc =
-              card.image_uris?.small ||
-              card.card_faces?.[0]?.image_uris?.small ||
+              card.image_uris?.normal ||
+              card.card_faces?.[0]?.image_uris?.normal ||
               null;
 
               return (


### PR DESCRIPTION
## Summary
- show "normal" card images on the dashboard card search results

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549de036d883208b34cd9cc247bf5f