### PR TITLE
Enable Spanish card search

### DIFF
--- a/apps/backend/src/card/controller/card.controller.ts
+++ b/apps/backend/src/card/controller/card.controller.ts
@@ -6,7 +6,7 @@ export class CardController {
   constructor(private readonly cardService: CardService) {}
 
   @Get('search')
-  search(@Query('q') query: string) {
-    return this.cardService.search(query);
+  search(@Query('q') query: string, @Query('lang') lang = 'en') {
+    return this.cardService.search(query, lang);
   }
 }

--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -27,10 +27,10 @@ describe('CardService', () => {
       json: jest.fn().mockResolvedValue(data),
     } as any);
 
-    const result = await service.search('test');
+    const result = await service.search('test', 'es');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.scryfall.com/cards/search?q=test',
+      'https://api.scryfall.com/cards/search?q=test&lang=es',
     );
     expect(result).toEqual(data);
   });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -4,10 +4,14 @@ import { Injectable } from '@nestjs/common';
 export class CardService {
   private readonly apiUrl = 'https://api.scryfall.com';
 
-  async search(query: string): Promise<any> {
-    const response = await fetch(
-      `${this.apiUrl}/cards/search?q=${encodeURIComponent(query)}`,
-    );
+  async search(query: string, lang = 'en'): Promise<any> {
+    const url = new URL(`${this.apiUrl}/cards/search`);
+    url.searchParams.set('q', query);
+    if (lang) {
+      url.searchParams.set('lang', lang);
+    }
+
+    const response = await fetch(url.toString());
 
     if (!response.ok) {
       throw new Error('Failed to fetch cards');

--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -55,7 +55,7 @@ export const Dashboard = ({ user, onLogout }: DashboardProps) => {
   const handleSearch = async () => {
     if (!query.trim()) return;
     try {
-      const data = await searchCards(query.trim());
+      const data = await searchCards(query.trim(), 'es');
       setResults(data.data || []);
     } catch (err) {
       console.warn(err);

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -75,10 +75,13 @@ export async function registerUser(data: {
   return await response.json();
 }
 
-export async function searchCards(query: string) {
-  const response = await fetch(
-    `${API_URL}/cards/search?q=${encodeURIComponent(query)}`,
-  );
+export async function searchCards(query: string, lang = 'es') {
+  const url = new URL(`${API_URL}/cards/search`);
+  url.searchParams.set('q', query);
+  if (lang) {
+    url.searchParams.set('lang', lang);
+  }
+  const response = await fetch(url.toString());
 
   if (!response.ok) {
     throw new Error('Failed to search cards');


### PR DESCRIPTION
## Summary
- allow language parameter in card search backend
- default frontend search to Spanish language
- update tests for new API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685536f443808320985c6078c3064529