### PR TITLE
Implement lang prefix in search

### DIFF
--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -30,7 +30,7 @@ describe('CardService', () => {
     const result = await service.search('test', 'es');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.scryfall.com/cards/search?q=test&lang=es',
+      'https://api.scryfall.com/cards/search?q=es:test&lang=es',
     );
     expect(result).toEqual(data);
   });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -6,7 +6,8 @@ export class CardService {
 
   async search(query: string, lang = 'en'): Promise<any> {
     const url = new URL(`${this.apiUrl}/cards/search`);
-    url.searchParams.set('q', query);
+    const searchQuery = lang && lang !== 'en' ? `${lang}:${query}` : query;
+    url.searchParams.set('q', searchQuery);
     if (lang) {
       url.searchParams.set('lang', lang);
     }

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -77,7 +77,8 @@ export async function registerUser(data: {
 
 export async function searchCards(query: string, lang = 'es') {
   const url = new URL(`${API_URL}/cards/search`);
-  url.searchParams.set('q', query);
+  const searchQuery = lang && lang !== 'en' ? `${lang}:${query}` : query;
+  url.searchParams.set('q', searchQuery);
   if (lang) {
     url.searchParams.set('lang', lang);
   }


### PR DESCRIPTION
## Summary
- support language prefixes in backend card search service
- update unit tests for backend search
- use same logic in frontend API

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in trade-web *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685544ac933c8320883eaaf5ea323c46