### PR TITLE
Fix card search

### DIFF
--- a/apps/backend/src/card/controller/card.controller.ts
+++ b/apps/backend/src/card/controller/card.controller.ts
@@ -6,7 +6,7 @@ export class CardController {
   constructor(private readonly cardService: CardService) {}
 
   @Get('search')
-  search(@Query('q') query: string, @Query('lang') lang = 'en') {
-    return this.cardService.search(query, lang);
+  search(@Query('q') query: string) {
+    return this.cardService.search(query);
   }
 }

--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -27,10 +27,10 @@ describe('CardService', () => {
       json: jest.fn().mockResolvedValue(data),
     } as any);
 
-    const result = await service.search('test', 'es');
+    const result = await service.search('test');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.scryfall.com/cards/search?q=es:test&lang=es',
+      'https://api.scryfall.com/cards/search?q=test',
     );
     expect(result).toEqual(data);
   });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -4,15 +4,10 @@ import { Injectable } from '@nestjs/common';
 export class CardService {
   private readonly apiUrl = 'https://api.scryfall.com';
 
-  async search(query: string, lang = 'en'): Promise<any> {
-    const url = new URL(`${this.apiUrl}/cards/search`);
-    const searchQuery = lang && lang !== 'en' ? `${lang}:${query}` : query;
-    url.searchParams.set('q', searchQuery);
-    if (lang) {
-      url.searchParams.set('lang', lang);
-    }
-
-    const response = await fetch(url.toString());
+  async search(query: string): Promise<any> {
+    const response = await fetch(
+      `${this.apiUrl}/cards/search?q=${encodeURIComponent(query)}`,
+    );
 
     if (!response.ok) {
       throw new Error('Failed to fetch cards');

--- a/apps/trade-web/src/Dashboard.tsx
+++ b/apps/trade-web/src/Dashboard.tsx
@@ -55,7 +55,7 @@ export const Dashboard = ({ user, onLogout }: DashboardProps) => {
   const handleSearch = async () => {
     if (!query.trim()) return;
     try {
-      const data = await searchCards(query.trim(), 'es');
+      const data = await searchCards(query.trim());
       setResults(data.data || []);
     } catch (err) {
       console.warn(err);

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -75,14 +75,10 @@ export async function registerUser(data: {
   return await response.json();
 }
 
-export async function searchCards(query: string, lang = 'es') {
-  const url = new URL(`${API_URL}/cards/search`);
-  const searchQuery = lang && lang !== 'en' ? `${lang}:${query}` : query;
-  url.searchParams.set('q', searchQuery);
-  if (lang) {
-    url.searchParams.set('lang', lang);
-  }
-  const response = await fetch(url.toString());
+export async function searchCards(query: string) {
+  const response = await fetch(
+    `${API_URL}/cards/search?q=${encodeURIComponent(query)}`,
+  );
 
   if (!response.ok) {
     throw new Error('Failed to search cards');


### PR DESCRIPTION
## Summary
- revert card search to only use English queries
- update backend tests for reverted behavior
- adjust frontend API and dashboard to not pass language codes

## Testing
- `npm --workspace apps/backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685546c6ce9c832081314cfe9f2b3886