### PR TITLE
Improve mobile layout for auth pages

### DIFF
--- a/apps/trade-web/src/Login.tsx
+++ b/apps/trade-web/src/Login.tsx
@@ -74,6 +74,7 @@ export const Login = ({ onUserLogin }: LoginProps) => {
           backgroundSize: "cover",
           backgroundRepeat: "no-repeat",
           backgroundPosition: "center",
+          display: { xs: "none", sm: "block" },
         }}
       />
       <Box
@@ -85,7 +86,7 @@ export const Login = ({ onUserLogin }: LoginProps) => {
           bgcolor: "background.default",
         }}
       >
-        <Box sx={{ width: 280, mx: "auto", p: 3 }}>
+        <Box sx={{ width: { xs: "100%", sm: 280 }, maxWidth: 280, mx: "auto", p: 3 }}>
           <Box display="flex" flexDirection="column" gap={2} width="100%">
             <Box textAlign="center">
               <img src={Logo} alt="Magic Friendly Trade logo" style={{ maxWidth: "200px", width: "100%" }} />

--- a/apps/trade-web/src/Register.tsx
+++ b/apps/trade-web/src/Register.tsx
@@ -69,6 +69,7 @@ export const Register = () => {
           backgroundSize: "cover",
           backgroundRepeat: "no-repeat",
           backgroundPosition: "left center",
+          display: { xs: "none", sm: "block" },
         }}
       />
       <Box
@@ -80,7 +81,7 @@ export const Register = () => {
           bgcolor: "background.default",
         }}
       >
-        <Box sx={{ width: 280, mx: "auto", p: 3 }}>
+        <Box sx={{ width: { xs: "100%", sm: 280 }, maxWidth: 280, mx: "auto", p: 3 }}>
           <Box display="flex" flexDirection="column" gap={2} width="100%">
             <Box textAlign="center">
               <img src={Logo} alt="Magic Friendly Trade logo" style={{ maxWidth: "200px", width: "100%" }} />


### PR DESCRIPTION
## Summary
- hide side images for Login and Register on small screens
- make login and register forms stretch to full width on mobile

## Testing
- `npm -w apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm -w apps/trade-web run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685595b1b4dc8320874a31c4ece7ee4a