### PR TITLE
Add search results header

### DIFF
--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Box, Container } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
 import NavBar from "./NavBar";
 import type { AuthUser } from "./Login";
 import { searchCards } from "./api";
@@ -13,10 +14,12 @@ type SearchResultsProps = {
 export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
   const location = useLocation();
   const [results, setResults] = useState<any[]>([]);
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const q = params.get("q") || "";
+    setQuery(q);
     if (!q) {
       setResults([]);
       return;
@@ -30,6 +33,12 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
     <Box sx={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
       <NavBar user={user} onLogout={onLogout} />
       <Container sx={{ mt: 2, flexGrow: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+          <SearchIcon sx={{ mr: 1 }} />
+          <Typography variant="h6">
+            {`Resultados para la búsqueda de "${query}"`}
+          </Typography>
+        </Box>
         <Box
           sx={{
             display: 'grid',


### PR DESCRIPTION
## Summary
- show a header with search query in search results

## Testing
- `npm --workspace apps/trade-web run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855b003469883209c99284b18fd8d7b