### PR TITLE
Add card detail page

### DIFF
--- a/apps/backend/src/card/controller/card.controller.ts
+++ b/apps/backend/src/card/controller/card.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { CardService } from '../service/card.service';
 
 @Controller('cards')
@@ -8,5 +8,10 @@ export class CardController {
   @Get('search')
   search(@Query('q') query: string) {
     return this.cardService.search(query);
+  }
+
+  @Get(':id')
+  getById(@Param('id') id: string) {
+    return this.cardService.getById(id);
   }
 }

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -15,4 +15,14 @@ export class CardService {
 
     return response.json();
   }
+
+  async getById(id: string): Promise<any> {
+    const response = await fetch(`${this.apiUrl}/cards/${id}`);
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch card');
+    }
+
+    return response.json();
+  }
 }

--- a/apps/trade-web/src/App.tsx
+++ b/apps/trade-web/src/App.tsx
@@ -5,6 +5,7 @@ import './App.css'
 import { Login, type AuthUser } from './Login'
 import { Dashboard } from './Dashboard'
 import { SearchResults } from './SearchResults'
+import { CardDetails } from './CardDetails'
 import Register from './Register'
 
 function App() {
@@ -73,6 +74,16 @@ function App() {
             element={
               user ? (
                 <SearchResults user={user} onLogout={handleLogout} />
+              ) : (
+                <Navigate to="/login" replace />
+              )
+            }
+          />
+          <Route
+            path="/cards/:id"
+            element={
+              user ? (
+                <CardDetails user={user} onLogout={handleLogout} />
               ) : (
                 <Navigate to="/login" replace />
               )

--- a/apps/trade-web/src/CardDetails.tsx
+++ b/apps/trade-web/src/CardDetails.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Box, Container, Typography } from '@mui/material'
+import NavBar from './NavBar'
+import type { AuthUser } from './Login'
+import { getCard } from './api'
+
+export type CardDetailsProps = {
+  user: AuthUser
+  onLogout: () => void
+}
+
+export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
+  const { id } = useParams()
+  const [card, setCard] = useState<any | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    getCard(id)
+      .then(setCard)
+      .catch((err) => console.warn(err))
+  }, [id])
+
+  const imgSrc =
+    card?.image_uris?.normal || card?.card_faces?.[0]?.image_uris?.normal || null
+
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <NavBar user={user} onLogout={onLogout} />
+      <Container sx={{ mt: 2, flexGrow: 1 }}>
+        {card ? (
+          <>
+            <Typography variant="h4" sx={{ mb: 2 }}>
+              {card.name}
+            </Typography>
+            {imgSrc && (
+              <Box
+                component="img"
+                src={imgSrc}
+                alt={card.name}
+                sx={{ maxWidth: 240, width: '100%', mb: 2 }}
+              />
+            )}
+            <Typography sx={{ mb: 1 }}>
+              <strong>Costo de maná:</strong> {card.mana_cost}
+            </Typography>
+            <Typography sx={{ mb: 1 }}>
+              <strong>Tipo:</strong> {card.type_line}
+            </Typography>
+            <Typography sx={{ whiteSpace: 'pre-line' }}>
+              <strong>Texto:</strong> {card.oracle_text}
+            </Typography>
+          </>
+        ) : (
+          <Typography>Cargando...</Typography>
+        )}
+      </Container>
+    </Box>
+  )
+}
+
+export default CardDetails

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Box, Container, Typography } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import NavBar from "./NavBar";
@@ -13,6 +13,7 @@ type SearchResultsProps = {
 
 export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
   const location = useLocation();
+  const navigate = useNavigate();
   const [results, setResults] = useState<any[]>([]);
   const [query, setQuery] = useState("");
 
@@ -63,7 +64,9 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
                   maxHeight: 336,
                   width: '100%',
                   overflow: 'hidden',
+                  cursor: 'pointer',
                 }}
+                onClick={() => navigate(`/cards/${card.id}`)}
               >
                 {imgSrc && (
                   <Box

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -87,6 +87,16 @@ export async function searchCards(query: string) {
   return await response.json();
 }
 
+export async function getCard(id: string) {
+  const response = await fetch(`${API_URL}/cards/${encodeURIComponent(id)}`);
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch card');
+  }
+
+  return await response.json();
+}
+
 export function authApi(token: string) {
   return {
     async me(token: string) {


### PR DESCRIPTION
## Summary
- extend backend card service and controller with `getById`
- expose `/cards/:id` API endpoint in frontend
- add CardDetails page to show selected card info
- link search result cards to CardDetails via React Router

## Testing
- `npm run lint` in `apps/trade-web` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in `apps/backend` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_6855b453278c8320a6ccb6c798e7dcd6