### PR TITLE
Modify card details layout

### DIFF
--- a/apps/trade-web/src/CardDetails.tsx
+++ b/apps/trade-web/src/CardDetails.tsx
@@ -33,23 +33,34 @@ export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
             <Typography variant="h4" sx={{ mb: 2 }}>
               {card.name}
             </Typography>
-            {imgSrc && (
-              <Box
-                component="img"
-                src={imgSrc}
-                alt={card.name}
-                sx={{ maxWidth: 240, width: '100%', mb: 2 }}
-              />
-            )}
-            <Typography sx={{ mb: 1 }}>
-              <strong>Costo de maná:</strong> {card.mana_cost}
-            </Typography>
-            <Typography sx={{ mb: 1 }}>
-              <strong>Tipo:</strong> {card.type_line}
-            </Typography>
-            <Typography sx={{ whiteSpace: 'pre-line' }}>
-              <strong>Texto:</strong> {card.oracle_text}
-            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: { xs: 'column', sm: 'row' },
+                alignItems: { xs: 'flex-start', sm: 'center' },
+                gap: 2,
+              }}
+            >
+              {imgSrc && (
+                <Box
+                  component="img"
+                  src={imgSrc}
+                  alt={card.name}
+                  sx={{ maxWidth: 240, width: '100%' }}
+                />
+              )}
+              <Box>
+                <Typography sx={{ mb: 1 }}>
+                  <strong>Costo de maná:</strong> {card.mana_cost}
+                </Typography>
+                <Typography sx={{ mb: 1 }}>
+                  <strong>Tipo:</strong> {card.type_line}
+                </Typography>
+                <Typography sx={{ whiteSpace: 'pre-line' }}>
+                  <strong>Texto:</strong> {card.oracle_text}
+                </Typography>
+              </Box>
+            </Box>
           </>
         ) : (
           <Typography>Cargando...</Typography>


### PR DESCRIPTION
## Summary
- layout CardDetails with the image on the left and its details on the right

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in `apps/trade-web` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855df89ff9c832080143739a6277994