### PR TITLE
Fix page text caret issue

### DIFF
--- a/apps/trade-web/src/index.css
+++ b/apps/trade-web/src/index.css
@@ -26,6 +26,16 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+input,
+textarea {
+  -webkit-user-select: auto;
+  -ms-user-select: auto;
+  user-select: auto;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- stop the text caret from showing when clicking on the page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685734b5e6708320ab599f56e20638ab