### PR TITLE
Add buttons to card search results

### DIFF
--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Container, Typography, Button } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import NavBar from "./NavBar";
 import type { AuthUser } from "./Login";
@@ -56,26 +56,51 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
               <Box
                 key={card.id}
                 sx={{
-                  mb: 0.25,
-                  border: '1px solid',
-                  borderColor: 'divider',
-                  borderRadius: 1,
+                  mb: 0.5,
                   maxWidth: 240,
-                  maxHeight: 336,
                   width: '100%',
-                  overflow: 'hidden',
-                  cursor: 'pointer',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
                 }}
-                onClick={() => navigate(`/cards/${card.id}`)}
               >
-                {imgSrc && (
-                  <Box
-                    component="img"
-                    src={imgSrc}
-                    alt={card.name}
-                    sx={{ display: 'block', maxWidth: 240, width: '100%' }}
-                  />
-                )}
+                <Box
+                  sx={{
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                    maxWidth: 240,
+                    maxHeight: 336,
+                    width: '100%',
+                    overflow: 'hidden',
+                    cursor: 'pointer',
+                  }}
+                  onClick={() => navigate(`/cards/${card.id}`)}
+                >
+                  {imgSrc && (
+                    <Box
+                      component="img"
+                      src={imgSrc}
+                      alt={card.name}
+                      sx={{ display: 'block', maxWidth: 240, width: '100%' }}
+                    />
+                  )}
+                </Box>
+                <Box
+                  sx={{
+                    mt: 0.5,
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'space-around',
+                  }}
+                >
+                  <Button size="small" variant="contained">
+                    La quiero
+                  </Button>
+                  <Button size="small" variant="outlined">
+                    La tengo
+                  </Button>
+                </Box>
               </Box>
             );
           })}


### PR DESCRIPTION
## Summary
- show action buttons under each card in search results

## Testing
- `npm run --workspace=apps/trade-web lint` *(fails: Cannot find package '@eslint/js')*
- `npm run --workspace=apps/trade-web build` *(fails: Cannot find module 'react')*
- `npm test --workspace=apps/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685738aa03bc8320bb5bc0860914fd42