### PR TITLE
Fetch card editions data

### DIFF
--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -30,8 +30,35 @@ describe('CardService', () => {
     const result = await service.search('test');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.scryfall.com/cards/search?q=test',
+      'https://api.scryfall.com/cards/search?q=test&include_multilingual=true',
     );
     expect(result).toEqual(data);
+  });
+
+  it('should fetch card and its prints', async () => {
+    const card = { prints_search_uri: 'http://example.com/cards/search?q=a' };
+    const prints = { data: [{ id: 1 }] };
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(card),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(prints),
+      } as any);
+
+    const result = await service.getById('123');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://api.scryfall.com/cards/123',
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://example.com/cards/search?q=a&include_multilingual=true',
+    );
+    expect(result).toEqual({ ...card, editions: prints.data });
   });
 });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -24,6 +24,26 @@ export class CardService {
       throw new Error('Failed to fetch card');
     }
 
-    return response.json();
+    const card = await response.json();
+
+    let printsUrl: string = card.prints_search_uri;
+
+    if (printsUrl && !printsUrl.includes('include_multilingual=')) {
+      printsUrl += (printsUrl.includes('?') ? '&' : '?') +
+        'include_multilingual=true';
+    }
+
+    if (printsUrl) {
+      const printsResponse = await fetch(printsUrl);
+
+      if (!printsResponse.ok) {
+        throw new Error('Failed to fetch card prints');
+      }
+
+      const prints = await printsResponse.json();
+      card.editions = prints.data;
+    }
+
+    return card;
   }
 }


### PR DESCRIPTION
## Summary
- extend card service to request prints
- test coverage for card `getById`
- ensure search uses `include_multilingual`

## Testing
- `npm test --prefix apps/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685981223af48320a930612e2c5f248a