### PR TITLE
Adjust edition images in modal

### DIFF
--- a/apps/trade-web/src/CardEditionModal.tsx
+++ b/apps/trade-web/src/CardEditionModal.tsx
@@ -54,10 +54,10 @@ export const CardEditionModal = ({
                   borderColor:
                     selectedIndex === idx ? 'primary.main' : 'divider',
                   borderWidth: selectedIndex === idx ? 2 : 1,
-                  borderRadius: 1,
+                  borderRadius: 0,
                   cursor: 'pointer',
-                  width: 80,
-                  height: 112,
+                  width: 120,
+                  height: 168,
                   overflow: 'hidden',
                 }}
                 onClick={() => setSelectedIndex(idx)}


### PR DESCRIPTION
## Summary
- enlarge edition image preview in the purchase modal
- remove rounded corners so editions show square images

## Testing
- `npm run lint -w apps/trade-web` *(fails: Cannot find package '@eslint/js')*
- `npm run test -w apps/backend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859884e1b308320a798260de901265e