### PR TITLE
Filter duplicates by edition and language

### DIFF
--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -21,7 +21,13 @@ describe('CardService', () => {
   });
 
   it('should fetch cards from scryfall', async () => {
-    const data = { data: [] };
+    const data = {
+      data: [
+        { id: 1, set_name: 'A', lang: 'en' },
+        { id: 2, set_name: 'A', lang: 'es' },
+        { id: 3, set_name: 'B', lang: 'en' },
+      ],
+    };
     const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: jest.fn().mockResolvedValue(data),
@@ -32,12 +38,20 @@ describe('CardService', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.scryfall.com/cards/search?q=test&include_multilingual=true',
     );
-    expect(result).toEqual(data);
+    expect(result.data).toEqual([
+      { id: 1, set_name: 'A', lang: 'en' },
+      { id: 3, set_name: 'B', lang: 'en' },
+    ]);
   });
 
   it('should fetch card and its prints', async () => {
     const card = { prints_search_uri: 'http://example.com/cards/search?q=a' };
-    const prints = { data: [{ id: 1 }] };
+    const prints = {
+      data: [
+        { id: 1, set_name: 'A', lang: 'en' },
+        { id: 2, set_name: 'A', lang: 'es' },
+      ],
+    };
     const fetchMock = jest
       .spyOn(global, 'fetch')
       .mockResolvedValueOnce({
@@ -59,6 +73,9 @@ describe('CardService', () => {
       2,
       'http://example.com/cards/search?q=a&include_multilingual=true',
     );
-    expect(result).toEqual({ ...card, editions: prints.data });
+    expect(result).toEqual({
+      ...card,
+      editions: [{ id: 1, set_name: 'A', lang: 'en' }],
+    });
   });
 });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -14,7 +14,19 @@ export class CardService {
       throw new Error('Failed to fetch cards');
     }
 
-    return response.json();
+    const result = await response.json();
+
+    if (Array.isArray(result?.data)) {
+      const unique: Record<string, any> = {};
+      result.data.forEach((card: any) => {
+        if (card.lang === 'en' && !unique[card.set_name]) {
+          unique[card.set_name] = card;
+        }
+      });
+      result.data = Object.values(unique);
+    }
+
+    return result;
   }
 
   async getById(id: string): Promise<any> {
@@ -41,7 +53,18 @@ export class CardService {
       }
 
       const prints = await printsResponse.json();
-      card.editions = prints.data;
+
+      if (Array.isArray(prints?.data)) {
+        const unique: Record<string, any> = {};
+        prints.data.forEach((ed: any) => {
+          if (ed.lang === 'en' && !unique[ed.set_name]) {
+            unique[ed.set_name] = ed;
+          }
+        });
+        card.editions = Object.values(unique);
+      } else {
+        card.editions = prints.data;
+      }
     }
 
     return card;


### PR DESCRIPTION
## Summary
- filter `/cards/search` results to unique English editions
- filter card print data so each edition appears once in English
- update CardService unit tests for filtering behavior

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b56d59c88320955e744b85ba85e3