### PR TITLE
Revert card search filter

### DIFF
--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -21,13 +21,7 @@ describe('CardService', () => {
   });
 
   it('should fetch cards from scryfall', async () => {
-    const data = {
-      data: [
-        { id: 1, set_name: 'A', lang: 'en' },
-        { id: 2, set_name: 'A', lang: 'es' },
-        { id: 3, set_name: 'B', lang: 'en' },
-      ],
-    };
+    const data = { data: [] };
     const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: jest.fn().mockResolvedValue(data),
@@ -38,20 +32,12 @@ describe('CardService', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.scryfall.com/cards/search?q=test&include_multilingual=true',
     );
-    expect(result.data).toEqual([
-      { id: 1, set_name: 'A', lang: 'en' },
-      { id: 3, set_name: 'B', lang: 'en' },
-    ]);
+    expect(result).toEqual(data);
   });
 
   it('should fetch card and its prints', async () => {
     const card = { prints_search_uri: 'http://example.com/cards/search?q=a' };
-    const prints = {
-      data: [
-        { id: 1, set_name: 'A', lang: 'en' },
-        { id: 2, set_name: 'A', lang: 'es' },
-      ],
-    };
+    const prints = { data: [{ id: 1 }] };
     const fetchMock = jest
       .spyOn(global, 'fetch')
       .mockResolvedValueOnce({
@@ -73,9 +59,6 @@ describe('CardService', () => {
       2,
       'http://example.com/cards/search?q=a&include_multilingual=true',
     );
-    expect(result).toEqual({
-      ...card,
-      editions: [{ id: 1, set_name: 'A', lang: 'en' }],
-    });
+    expect(result).toEqual({ ...card, editions: prints.data });
   });
 });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -14,19 +14,7 @@ export class CardService {
       throw new Error('Failed to fetch cards');
     }
 
-    const result = await response.json();
-
-    if (Array.isArray(result?.data)) {
-      const unique: Record<string, any> = {};
-      result.data.forEach((card: any) => {
-        if (card.lang === 'en' && !unique[card.set_name]) {
-          unique[card.set_name] = card;
-        }
-      });
-      result.data = Object.values(unique);
-    }
-
-    return result;
+    return response.json();
   }
 
   async getById(id: string): Promise<any> {
@@ -53,18 +41,7 @@ export class CardService {
       }
 
       const prints = await printsResponse.json();
-
-      if (Array.isArray(prints?.data)) {
-        const unique: Record<string, any> = {};
-        prints.data.forEach((ed: any) => {
-          if (ed.lang === 'en' && !unique[ed.set_name]) {
-            unique[ed.set_name] = ed;
-          }
-        });
-        card.editions = Object.values(unique);
-      } else {
-        card.editions = prints.data;
-      }
+      card.editions = prints.data;
     }
 
     return card;


### PR DESCRIPTION
## Summary
- revert filtering of search results by edition and language

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b82d89bc8320930bee21aeb5307c