### PR TITLE
Filter English card editions

### DIFF
--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -37,7 +37,13 @@ describe('CardService', () => {
 
   it('should fetch card and its prints', async () => {
     const card = { prints_search_uri: 'http://example.com/cards/search?q=a' };
-    const prints = { data: [{ id: 1 }] };
+    const prints = {
+      data: [
+        { id: 1, set_name: 'A', lang: 'es' },
+        { id: 2, set_name: 'A', lang: 'en' },
+        { id: 3, set_name: 'B', lang: 'de' },
+      ],
+    };
     const fetchMock = jest
       .spyOn(global, 'fetch')
       .mockResolvedValueOnce({
@@ -59,6 +65,9 @@ describe('CardService', () => {
       2,
       'http://example.com/cards/search?q=a&include_multilingual=true',
     );
-    expect(result).toEqual({ ...card, editions: prints.data });
+    expect(result).toEqual({
+      ...card,
+      editions: [prints.data[1], prints.data[2]],
+    });
   });
 });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -41,7 +41,15 @@ export class CardService {
       }
 
       const prints = await printsResponse.json();
-      card.editions = prints.data;
+      const editions: Record<string, any> = {};
+      for (const ed of prints.data ?? []) {
+        const key = ed.set_name;
+        const existing = editions[key];
+        if (!existing || (existing.lang !== 'en' && ed.lang === 'en')) {
+          editions[key] = ed;
+        }
+      }
+      card.editions = Object.values(editions);
     }
 
     return card;


### PR DESCRIPTION
## Summary
- only keep one edition per set on getById service call with English preference
- test unique English edition filtering

## Testing
- `npm test --workspace apps/backend` *(fails: jest not found)*
- `npm run lint --workspace apps/backend` *(fails: ESLint couldn't find config)*
- `npm run lint --workspace apps/trade-web` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ba394a3c83209734ca4df406ab18