### PR TITLE
Display all English card editions

### DIFF
--- a/apps/backend/src/card/service/card.service.spec.ts
+++ b/apps/backend/src/card/service/card.service.spec.ts
@@ -67,7 +67,7 @@ describe('CardService', () => {
     );
     expect(result).toEqual({
       ...card,
-      editions: [prints.data[1], prints.data[2]],
+      editions: [prints.data[1]],
     });
   });
 });

--- a/apps/backend/src/card/service/card.service.ts
+++ b/apps/backend/src/card/service/card.service.ts
@@ -41,15 +41,7 @@ export class CardService {
       }
 
       const prints = await printsResponse.json();
-      const editions: Record<string, any> = {};
-      for (const ed of prints.data ?? []) {
-        const key = ed.set_name;
-        const existing = editions[key];
-        if (!existing || (existing.lang !== 'en' && ed.lang === 'en')) {
-          editions[key] = ed;
-        }
-      }
-      card.editions = Object.values(editions);
+      card.editions = (prints.data ?? []).filter((ed) => ed.lang === 'en');
     }
 
     return card;


### PR DESCRIPTION
## Summary
- ensure the backend returns only English editions for a card
- update tests to match new backend behavior

## Testing
- `npm test --workspace apps/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d6e9f29c83208c0e3e7851f703b4