### PR TITLE
Add wishlist checkbox and language selector

### DIFF
--- a/apps/trade-web/src/CardEditionModal.tsx
+++ b/apps/trade-web/src/CardEditionModal.tsx
@@ -6,13 +6,23 @@ import {
   DialogActions,
   Button,
   Box,
+  FormControlLabel,
+  Checkbox,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material'
 
 export type CardEditionModalProps = {
   open: boolean
   editions: any[]
   onClose: () => void
-  onConfirm?: (edition: any) => void
+  onConfirm?: (
+    edition: any,
+    addToWishlist: boolean,
+    language: string
+  ) => void
 }
 
 export const CardEditionModal = ({
@@ -22,10 +32,24 @@ export const CardEditionModal = ({
   onConfirm,
 }: CardEditionModalProps) => {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
+  const [addToWishlist, setAddToWishlist] = useState(false)
+  const [language, setLanguage] = useState('EN')
+  const LANGUAGES = [
+    'EN',
+    'ES',
+    'FR',
+    'DE',
+    'IT',
+    'PT',
+    'JA',
+    'KO',
+    'RU',
+    'ZH',
+  ]
 
   const handleConfirm = () => {
     if (selectedIndex != null && onConfirm) {
-      onConfirm(editions[selectedIndex])
+      onConfirm(editions[selectedIndex], addToWishlist, language)
     }
     onClose()
   }
@@ -75,6 +99,32 @@ export const CardEditionModal = ({
               </Box>
             )
           })}
+        </Box>
+        <Box sx={{ mt: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={addToWishlist}
+                onChange={(e) => setAddToWishlist(e.target.checked)}
+              />
+            }
+            label="Agregar a mi lista de deseos"
+          />
+          <FormControl size="small">
+            <InputLabel id="language-label">Idioma</InputLabel>
+            <Select
+              labelId="language-label"
+              value={language}
+              label="Idioma"
+              onChange={(e) => setLanguage(e.target.value as string)}
+            >
+              {LANGUAGES.map((lang) => (
+                <MenuItem key={lang} value={lang}>
+                  {lang}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </Box>
       </DialogContent>
       <DialogActions sx={{ p: 2 }}>

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -152,8 +152,8 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
         open={editionOpen}
         editions={selectedCard?.editions ?? []}
         onClose={() => setEditionOpen(false)}
-        onConfirm={(ed) => {
-          setSelectedEdition(ed);
+        onConfirm={(_ed, _wishlist, _language) => {
+          setSelectedEdition(_ed);
           setEditionOpen(false);
         }}
       />


### PR DESCRIPTION
## Summary
- update `CardEditionModal` to include new wishlist and language options
- adjust `SearchResults` to handle new modal props

## Testing
- `npm --workspace apps/trade-web run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm --workspace apps/trade-web run build` *(fails: missing dependencies)*
- `npm --workspace apps/backend test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a86d2fa1c832083c0035cdbd5b4e6