### PR TITLE
Fix CardEditionModal footer layout

### DIFF
--- a/apps/trade-web/src/CardEditionModal.tsx
+++ b/apps/trade-web/src/CardEditionModal.tsx
@@ -101,46 +101,69 @@ export const CardEditionModal = ({
             )
           })}
         </Box>
-        <Box sx={{ mt: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={addToWishlist}
-                onChange={(e) => setAddToWishlist(e.target.checked)}
-                color="success"
-                sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
-              />
-            }
-            label="Agregar a mi lista de deseos"
-          />
-          <FormControl size="small" sx={{ minWidth: 160 }}>
-            <InputLabel id="language-label">Idioma</InputLabel>
-            <Select
-              labelId="language-label"
-              value={language}
-              label="Idioma"
-              onChange={(e) => setLanguage(e.target.value as string)}
-              color="success"
-              sx={{ textTransform: 'capitalize' }}
-            >
-              {LANGUAGES.map((lang) => (
-                <MenuItem key={lang} value={lang}>
-                  {lang}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Box>
       </DialogContent>
-      <DialogActions sx={{ p: 2 }}>
-        <Button
-          variant="contained"
-          fullWidth
-          onClick={handleConfirm}
-          disabled={selectedIndex === null}
+      <DialogActions
+        sx={{
+          p: 2,
+          position: 'sticky',
+          bottom: 0,
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            gap: 2,
+          }}
         >
-          Buscar Vendedores
-        </Button>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={addToWishlist}
+                  onChange={(e) => setAddToWishlist(e.target.checked)}
+                  color="success"
+                  sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
+                />
+              }
+              label="Agregar a mi lista de deseos"
+            />
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel id="language-label">Idioma</InputLabel>
+              <Select
+                labelId="language-label"
+                value={language}
+                label="Idioma"
+                onChange={(e) => setLanguage(e.target.value as string)}
+                color="success"
+                sx={{ textTransform: 'capitalize' }}
+              >
+                {LANGUAGES.map((lang) => (
+                  <MenuItem key={lang} value={lang}>
+                    {lang}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+          <Button
+            variant="contained"
+            color="success"
+            sx={{
+              textTransform: 'none',
+              borderRadius: 3,
+              boxShadow: 2,
+              '&:hover': { boxShadow: 3 },
+            }}
+            onClick={handleConfirm}
+            disabled={selectedIndex === null}
+          >
+            Buscar Vendedores
+          </Button>
+        </Box>
       </DialogActions>
     </Dialog>
   )


### PR DESCRIPTION
## Summary
- keep wishlist checkbox, language dropdown and search button together in the modal footer
- style `Buscar Vendedores` button using MUI

## Testing
- `npm --prefix apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix apps/backend run lint` *(fails: ESLint couldn't find config)*
- `npm --prefix apps/backend test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8f09f05883208ba81ea11fc08138