### PR TITLE
Add language and wishlist fields

### DIFF
--- a/apps/backend/src/collection/controller/wishlist.controller.ts
+++ b/apps/backend/src/collection/controller/wishlist.controller.ts
@@ -25,6 +25,8 @@ export class WishlistController {
         imageUrl: dto.imageUrl,
       } as any,
       desiredQuantity: dto.desiredQuantity,
+      language: dto.language,
+      addToWishlist: dto.addToWishlist,
     });
   }
 

--- a/apps/backend/src/collection/dto/create-wishlist-item.dto.ts
+++ b/apps/backend/src/collection/dto/create-wishlist-item.dto.ts
@@ -3,4 +3,6 @@ export class CreateWishlistItemDto {
   desiredQuantity: number;
   cardName: string;
   imageUrl?: string;
+  language: string;
+  addToWishlist: boolean;
 }

--- a/apps/backend/src/collection/dto/update-wishlist-item.dto.ts
+++ b/apps/backend/src/collection/dto/update-wishlist-item.dto.ts
@@ -1,3 +1,5 @@
 export class UpdateWishlistItemDto {
   desiredQuantity?: number;
+  language?: string;
+  addToWishlist?: boolean;
 }

--- a/apps/backend/src/collection/entity/wishlist-item.entity.ts
+++ b/apps/backend/src/collection/entity/wishlist-item.entity.ts
@@ -15,4 +15,10 @@ export class WishlistItem {
 
   @Column({ default: 1 })
   desiredQuantity: number;
+
+  @Column({ default: 'indiferente' })
+  language: string;
+
+  @Column({ default: false })
+  addToWishlist: boolean;
 }


### PR DESCRIPTION
## Summary
- expand WishlistItem entity with language and addToWishlist properties
- extend create/update DTOs accordingly
- include new fields when creating wishlist items

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a934d09c4832093290bad4a59be57