### PR TITLE
Add quantity selector next to language in card modal

### DIFF
--- a/apps/trade-web/src/CardEditionModal.tsx
+++ b/apps/trade-web/src/CardEditionModal.tsx
@@ -14,6 +14,8 @@ import {
   MenuItem,
 } from '@mui/material'
 
+export type Quantity = 'indiferente' | 1 | 2 | 3 | 4
+
 export type CardEditionModalProps = {
   open: boolean
   editions: any[]
@@ -21,7 +23,8 @@ export type CardEditionModalProps = {
   onConfirm?: (
     edition: any,
     addToWishlist: boolean,
-    language: string
+    language: string,
+    quantity: Quantity
   ) => void
 }
 
@@ -34,6 +37,7 @@ export const CardEditionModal = ({
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const [addToWishlist, setAddToWishlist] = useState(false)
   const [language, setLanguage] = useState('indiferente')
+  const [quantity, setQuantity] = useState<Quantity>('indiferente')
   const LANGUAGES = [
     'indiferente',
     'EN',
@@ -47,10 +51,11 @@ export const CardEditionModal = ({
     'RU',
     'ZH',
   ]
+  const QUANTITIES: Quantity[] = ['indiferente', 1, 2, 3, 4]
 
   const handleConfirm = () => {
     if (selectedIndex != null && onConfirm) {
-      onConfirm(editions[selectedIndex], addToWishlist, language)
+      onConfirm(editions[selectedIndex], addToWishlist, language, quantity)
     }
     onClose()
   }
@@ -144,6 +149,24 @@ export const CardEditionModal = ({
                 {LANGUAGES.map((lang) => (
                   <MenuItem key={lang} value={lang}>
                     {lang}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel id="quantity-label">Cantidad</InputLabel>
+              <Select
+                labelId="quantity-label"
+                value={quantity}
+                label="Cantidad"
+                onChange={(e) =>
+                  setQuantity(e.target.value as Quantity)
+                }
+                color="success"
+              >
+                {QUANTITIES.map((qt) => (
+                  <MenuItem key={qt} value={qt}>
+                    {qt}
                   </MenuItem>
                 ))}
               </Select>

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -152,7 +152,7 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
         open={editionOpen}
         editions={selectedCard?.editions ?? []}
         onClose={() => setEditionOpen(false)}
-        onConfirm={(_ed, _wishlist, _language) => {
+        onConfirm={(_ed, _wishlist, _language, _quantity) => {
           setSelectedEdition(_ed);
           setEditionOpen(false);
         }}


### PR DESCRIPTION
## Summary
- adjust `CardEditionModal` callback signature
- add quantity select with `Indiferente` and 1–4 options
- update `SearchResults` to use new callback signature

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` in trade-web *(fails: missing dependencies)*
- `npm run lint` in trade-web *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a97d324108320881d7d112268da02