### PR TITLE
Add sellers search endpoint and grid

### DIFF
--- a/apps/backend/src/collection/controller/inventory.controller.ts
+++ b/apps/backend/src/collection/controller/inventory.controller.ts
@@ -1,13 +1,29 @@
-import { Controller, Get, Post, Body, Param, Delete, Put, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  Put,
+  UseGuards,
+  Request,
+  ParseUUIDPipe,
+} from '@nestjs/common';
 import { InventoryService } from '../service/inventory.service';
+import { WishlistService } from '../service/wishlist.service';
 import { CreateInventoryItemDto } from '../dto/create-inventory-item.dto';
 import { UpdateInventoryItemDto } from '../dto/update-inventory-item.dto';
+import { FindSellersDto } from '../dto/find-sellers.dto';
 import { AuthGuard } from '@nestjs/passport';
 
 @UseGuards(AuthGuard('jwt'))
 @Controller('inventory')
 export class InventoryController {
-  constructor(private readonly inventoryService: InventoryService) {}
+  constructor(
+    private readonly inventoryService: InventoryService,
+    private readonly wishlistService: WishlistService,
+  ) {}
 
   @Get()
   findAll(@Request() req) {
@@ -26,6 +42,29 @@ export class InventoryController {
       } as any,
       quantity: dto.quantity,
     });
+  }
+
+  @Post('find-sellers')
+  async findSellers(@Request() req, @Body() dto: FindSellersDto) {
+    if (dto.addToWishlist) {
+      await this.wishlistService.create({
+        user: { id: req.user.userId } as any,
+        card: {
+          id: dto.cardId,
+          name: dto.cardName,
+          imageUrl: dto.imageUrl,
+        } as any,
+        desiredQuantity: dto.quantity,
+        language: dto.language,
+        addToWishlist: true,
+      });
+    }
+    return this.inventoryService.findByCard(dto.cardId);
+  }
+
+  @Get('card/:id')
+  findByCard(@Param('id') id: string) {
+    return this.inventoryService.findByCard(id);
   }
 
   @Put(':id')

--- a/apps/backend/src/collection/dto/find-sellers.dto.ts
+++ b/apps/backend/src/collection/dto/find-sellers.dto.ts
@@ -1,0 +1,8 @@
+export class FindSellersDto {
+  cardId: string;
+  cardName: string;
+  imageUrl?: string;
+  language: string;
+  quantity: number;
+  addToWishlist: boolean;
+}

--- a/apps/backend/src/collection/repository/inventory-item.repository.ts
+++ b/apps/backend/src/collection/repository/inventory-item.repository.ts
@@ -18,6 +18,10 @@ export class InventoryItemRepository {
     return this.repository.findOne({ where: { id } });
   }
 
+  findByCard(cardId: string): Promise<InventoryItem[]> {
+    return this.repository.find({ where: { card: { id: cardId } } });
+  }
+
   async createAndSave(data: Partial<InventoryItem>): Promise<InventoryItem> {
     const item = this.repository.create(data);
     return this.repository.save(item);

--- a/apps/backend/src/collection/service/inventory.service.spec.ts
+++ b/apps/backend/src/collection/service/inventory.service.spec.ts
@@ -12,6 +12,7 @@ describe('InventoryService', () => {
     const repoMock: jest.Mocked<InventoryItemRepository> = {
       findByUser: jest.fn(),
       findById: jest.fn(),
+      findByCard: jest.fn(),
       createAndSave: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),

--- a/apps/backend/src/collection/service/inventory.service.ts
+++ b/apps/backend/src/collection/service/inventory.service.ts
@@ -18,6 +18,10 @@ export class InventoryService {
     return this.repository.findById(id);
   }
 
+  findByCard(cardId: string): Promise<InventoryItem[]> {
+    return this.repository.findByCard(cardId);
+  }
+
   async create(data: Partial<InventoryItem>): Promise<InventoryItem> {
     if (data.card) {
       const existing = await this.cardService.findById(data.card.id);

--- a/apps/trade-web/src/CardDetails.tsx
+++ b/apps/trade-web/src/CardDetails.tsx
@@ -1,9 +1,18 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Box, Container, Typography } from '@mui/material'
+import {
+  Box,
+  Container,
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@mui/material'
 import NavBar from './NavBar'
 import type { AuthUser } from './Login'
-import { getCard } from './api'
+import { getCard, getSellers } from './api'
 
 export type CardDetailsProps = {
   user: AuthUser
@@ -13,6 +22,7 @@ export type CardDetailsProps = {
 export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
   const { id } = useParams()
   const [card, setCard] = useState<any | null>(null)
+  const [sellers, setSellers] = useState<any[]>([])
 
   useEffect(() => {
     if (!id) return
@@ -20,6 +30,13 @@ export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
       .then(setCard)
       .catch((err) => console.warn(err))
   }, [id])
+
+  useEffect(() => {
+    if (!id) return
+    getSellers(id, user.access_token)
+      .then(setSellers)
+      .catch((err) => console.warn(err))
+  }, [id, user.access_token])
 
   const imgSrc =
     card?.image_uris?.normal || card?.card_faces?.[0]?.image_uris?.normal || null
@@ -63,6 +80,32 @@ export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
                   <strong>Texto:</strong> {card.oracle_text}
                 </Typography>
               </Box>
+            </Box>
+            <Box sx={{ mt: 4 }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Usuario</TableCell>
+                    <TableCell>Foil</TableCell>
+                    <TableCell>Firmada</TableCell>
+                    <TableCell>Comentario</TableCell>
+                    <TableCell>Cantidad</TableCell>
+                    <TableCell>Idioma</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sellers.map((s) => (
+                    <TableRow key={s.id}>
+                      <TableCell>{s.user?.username}</TableCell>
+                      <TableCell>No</TableCell>
+                      <TableCell>No</TableCell>
+                      <TableCell></TableCell>
+                      <TableCell>{s.quantity}</TableCell>
+                      <TableCell>indiferente</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </Box>
           </>
         ) : (

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -7,7 +7,12 @@ import SellIcon from "@mui/icons-material/Sell";
 import NavBar from "./NavBar";
 import type { AuthUser } from "./Login";
 import CardEditionModal from "./CardEditionModal";
-import { searchCards, getCard, type CardWithEditions } from "./api";
+import {
+  searchCards,
+  getCard,
+  type CardWithEditions,
+  findSellers,
+} from "./api";
 
 type SearchResultsProps = {
   user: AuthUser;
@@ -152,9 +157,28 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
         open={editionOpen}
         editions={selectedCard?.editions ?? []}
         onClose={() => setEditionOpen(false)}
-        onConfirm={(_ed, _wishlist, _language, _quantity) => {
+        onConfirm={async (_ed, _wishlist, _language, _quantity) => {
           setSelectedEdition(_ed);
           setEditionOpen(false);
+          try {
+            await findSellers(
+              {
+                cardId: _ed.id,
+                cardName: selectedCard?.name ?? '',
+                imageUrl:
+                  _ed.image_uris?.normal ||
+                  _ed.card_faces?.[0]?.image_uris?.normal ||
+                  '',
+                language: _language,
+                quantity: _quantity === 'indiferente' ? 1 : (_quantity as number),
+                addToWishlist: _wishlist,
+              },
+              user.access_token,
+            );
+            navigate(`/cards/${_ed.id}`);
+          } catch (err) {
+            console.warn(err);
+          }
         }}
       />
     </Box>

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -107,6 +107,42 @@ export async function getCard(id: string): Promise<CardWithEditions> {
   return (await response.json()) as CardWithEditions;
 }
 
+export async function findSellers(
+  data: {
+    cardId: string;
+    cardName: string;
+    imageUrl?: string;
+    language: string;
+    quantity: number;
+    addToWishlist: boolean;
+  },
+  token: string,
+) {
+  const response = await jsonFetch(API_URL + "/inventory/find-sellers", {
+    method: "POST",
+    payload: data,
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to find sellers");
+  }
+
+  return await response.json();
+}
+
+export async function getSellers(cardId: string, token: string) {
+  const response = await fetch(`${API_URL}/inventory/card/${encodeURIComponent(cardId)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch sellers');
+  }
+
+  return await response.json();
+}
+
 export function authApi(token: string) {
   return {
     async me(token: string) {


### PR DESCRIPTION
## Summary
- add `find-sellers` DTO
- support fetching inventory by card
- expose new `/inventory/find-sellers` and `/inventory/card/:id` endpoints
- call the new endpoint from search results modal
- show sellers table on card details

## Testing
- `npm --prefix apps/backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9e133f8c8320b299d9f256eef021