### PR TITLE
Inject CardService in wishlist service

### DIFF
--- a/apps/backend/src/collection/service/wishlist.service.spec.ts
+++ b/apps/backend/src/collection/service/wishlist.service.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WishlistService } from './wishlist.service';
 import { WishlistItemRepository } from '../repository/wishlist-item.repository';
+import { CardService } from './card.service';
 
 describe('WishlistService', () => {
   let service: WishlistService;
   let repo: jest.Mocked<WishlistItemRepository>;
+  let card: jest.Mocked<CardService>;
 
   beforeEach(async () => {
     const repoMock: jest.Mocked<WishlistItemRepository> = {
@@ -15,23 +17,33 @@ describe('WishlistService', () => {
       remove: jest.fn(),
     } as any;
 
+    const cardMock: jest.Mocked<CardService> = {
+      findById: jest.fn(),
+      create: jest.fn(),
+    } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WishlistService,
         { provide: WishlistItemRepository, useValue: repoMock },
+        { provide: CardService, useValue: cardMock },
       ],
     }).compile();
 
     service = module.get<WishlistService>(WishlistService);
     repo = module.get(WishlistItemRepository);
+    card = module.get(CardService);
   });
 
   it('should create an item', async () => {
     const item: any = { id: '1' };
     repo.createAndSave.mockResolvedValue(item);
-    const result = await service.create({});
+    card.findById.mockResolvedValue(null);
+    const result = await service.create({ card: { id: 'card1' } } as any);
     expect(result).toBe(item);
     expect(repo.createAndSave).toHaveBeenCalled();
+    expect(card.findById).toHaveBeenCalledWith('card1');
+    expect(card.create).toHaveBeenCalled();
   });
 
   it('should update an item', async () => {

--- a/apps/backend/src/collection/service/wishlist.service.ts
+++ b/apps/backend/src/collection/service/wishlist.service.ts
@@ -1,10 +1,14 @@
 import { Injectable, ForbiddenException } from '@nestjs/common';
 import { WishlistItemRepository } from '../repository/wishlist-item.repository';
 import { WishlistItem } from '../entity/wishlist-item.entity';
+import { CardService } from './card.service';
 
 @Injectable()
 export class WishlistService {
-  constructor(private readonly repository: WishlistItemRepository) {}
+  constructor(
+    private readonly repository: WishlistItemRepository,
+    private readonly cardService: CardService,
+  ) {}
 
   findByUser(userId: string): Promise<WishlistItem[]> {
     return this.repository.findByUser(userId);
@@ -14,7 +18,13 @@ export class WishlistService {
     return this.repository.findById(id);
   }
 
-  create(data: Partial<WishlistItem>): Promise<WishlistItem> {
+  async create(data: Partial<WishlistItem>): Promise<WishlistItem> {
+    if (data.card) {
+      const existing = await this.cardService.findById(data.card.id);
+      if (!existing) {
+        await this.cardService.create(data.card as any);
+      }
+    }
     return this.repository.createAndSave(data);
   }
 


### PR DESCRIPTION
## Summary
- inject `CardService` into `WishlistService`
- create missing cards when adding items to wishlist
- mock `CardService` in wishlist service unit tests
- verify card retrieval & creation during wishlist item creation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab771713883209ef2777fdbdf2b6c