### PR TITLE
Add wishlist image support

### DIFF
--- a/apps/backend/src/collection/controller/inventory.controller.ts
+++ b/apps/backend/src/collection/controller/inventory.controller.ts
@@ -54,6 +54,7 @@ export class InventoryController {
           name: dto.cardName,
           imageUrl: dto.imageUrl,
         } as any,
+        imageUrl: dto.imageUrl,
         desiredQuantity: dto.quantity,
         language: dto.language,
       });

--- a/apps/backend/src/collection/controller/wishlist.controller.ts
+++ b/apps/backend/src/collection/controller/wishlist.controller.ts
@@ -24,6 +24,7 @@ export class WishlistController {
         name: dto.cardName,
         imageUrl: dto.imageUrl,
       } as any,
+      imageUrl: dto.imageUrl,
       desiredQuantity: dto.desiredQuantity,
       language: dto.language,
     });

--- a/apps/backend/src/collection/dto/update-wishlist-item.dto.ts
+++ b/apps/backend/src/collection/dto/update-wishlist-item.dto.ts
@@ -1,4 +1,5 @@
 export class UpdateWishlistItemDto {
   desiredQuantity?: number;
   language?: string;
+  imageUrl?: string;
 }

--- a/apps/backend/src/collection/entity/wishlist-item.entity.ts
+++ b/apps/backend/src/collection/entity/wishlist-item.entity.ts
@@ -13,6 +13,9 @@ export class WishlistItem {
   @ManyToOne(() => Card, { eager: true })
   card: Card;
 
+  @Column({ nullable: true })
+  imageUrl?: string;
+
   @Column({ default: 1 })
   desiredQuantity: number;
 


### PR DESCRIPTION
## Summary
- allow storing an image per wishlist item
- expose optional imageUrl in update DTO
- attach chosen edition image when creating wishlist entries

## Testing
- `npm run build --workspace=apps/backend` *(fails: nest not found)*
- `npm test --workspace=apps/backend` *(fails: jest not found)*
- `npm run lint --workspace=apps/trade-web` *(fails: missing eslint deps)*

------
https://chatgpt.com/codex/tasks/task_e_685ac0cdb0ec8320a958610f36932a12