### PR TITLE
Add wishlist delete feature

### DIFF
--- a/apps/trade-web/src/Wishlist.tsx
+++ b/apps/trade-web/src/Wishlist.tsx
@@ -9,11 +9,16 @@ import {
   TableCell,
   TableBody,
   Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  Button,
 } from '@mui/material'
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
+import DeleteIcon from '@mui/icons-material/Delete'
 import NavBar from './NavBar'
 import type { AuthUser } from './Login'
-import { getWishlist } from './api'
+import { getWishlist, deleteWishlistItem } from './api'
 
 export type WishlistProps = {
   user: AuthUser
@@ -22,6 +27,7 @@ export type WishlistProps = {
 
 export const Wishlist = ({ user, onLogout }: WishlistProps) => {
   const [items, setItems] = useState<any[]>([])
+  const [deleteId, setDeleteId] = useState<string | null>(null)
 
   useEffect(() => {
     getWishlist(user.access_token)
@@ -43,6 +49,7 @@ export const Wishlist = ({ user, onLogout }: WishlistProps) => {
               <TableCell>Nombre</TableCell>
               <TableCell>Cantidad</TableCell>
               <TableCell>Idioma</TableCell>
+              <TableCell />
             </TableRow>
           </TableHead>
           <TableBody>
@@ -72,10 +79,42 @@ export const Wishlist = ({ user, onLogout }: WishlistProps) => {
                 <TableCell sx={{ textTransform: 'capitalize' }}>
                   {item.language}
                 </TableCell>
+                <TableCell>
+                  <DeleteIcon
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => setDeleteId(item.id)}
+                  />
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
+        <Dialog open={Boolean(deleteId)} onClose={() => setDeleteId(null)}>
+          <DialogTitle>
+            ¿Estás seguro de que quieres eliminar esta carta?
+          </DialogTitle>
+          <DialogActions>
+            <Button onClick={() => setDeleteId(null)}>Cancelar</Button>
+            <Button
+              onClick={async () => {
+                if (deleteId) {
+                  try {
+                    await deleteWishlistItem(deleteId, user.access_token)
+                    setItems(items.filter((it) => it.id !== deleteId))
+                  } catch (err) {
+                    console.warn(err)
+                  } finally {
+                    setDeleteId(null)
+                  }
+                }
+              }}
+              color="error"
+              variant="contained"
+            >
+              Sí
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Container>
     </Box>
   )

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -155,6 +155,17 @@ export async function getWishlist(token: string) {
   return await response.json();
 }
 
+export async function deleteWishlistItem(id: string, token: string) {
+  const response = await fetch(`${API_URL}/wishlist/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to delete wishlist item');
+  }
+}
+
 export function authApi(token: string) {
   return {
     async me(token: string) {


### PR DESCRIPTION
## Summary
- add API helper to delete wishlist items
- add trash icon and confirmation dialog in Wishlist

## Testing
- `npm run lint -w apps/trade-web` *(fails: Cannot find package '@eslint/js')*
- `npm run build -w apps/trade-web` *(fails: npm error command sh -c tsc -b && vite build)*

------
https://chatgpt.com/codex/tasks/task_e_685acac122d88320bb30dd6587b415ff