### PR TITLE
Enable edition-only seller search

### DIFF
--- a/apps/backend/src/collection/controller/inventory.controller.ts
+++ b/apps/backend/src/collection/controller/inventory.controller.ts
@@ -55,8 +55,8 @@ export class InventoryController {
           imageUrl: dto.imageUrl,
         } as any,
         imageUrl: dto.imageUrl,
-        desiredQuantity: dto.quantity,
-        language: dto.language,
+        desiredQuantity: dto.quantity ?? 1,
+        language: dto.language ?? 'indiferente',
       });
     }
     return this.inventoryService.findByCard(dto.cardId);

--- a/apps/backend/src/collection/controller/wishlist.controller.ts
+++ b/apps/backend/src/collection/controller/wishlist.controller.ts
@@ -25,8 +25,8 @@ export class WishlistController {
         imageUrl: dto.imageUrl,
       } as any,
       imageUrl: dto.imageUrl,
-      desiredQuantity: dto.desiredQuantity,
-      language: dto.language,
+      desiredQuantity: dto.desiredQuantity ?? 1,
+      language: dto.language ?? 'indiferente',
     });
   }
 

--- a/apps/backend/src/collection/dto/create-wishlist-item.dto.ts
+++ b/apps/backend/src/collection/dto/create-wishlist-item.dto.ts
@@ -1,7 +1,7 @@
 export class CreateWishlistItemDto {
   cardId: string;
-  desiredQuantity: number;
+  desiredQuantity?: number;
   cardName: string;
   imageUrl?: string;
-  language: string;
+  language?: string;
 }

--- a/apps/backend/src/collection/dto/find-sellers.dto.ts
+++ b/apps/backend/src/collection/dto/find-sellers.dto.ts
@@ -2,7 +2,7 @@ export class FindSellersDto {
   cardId: string;
   cardName: string;
   imageUrl?: string;
-  language: string;
-  quantity: number;
+  language?: string;
+  quantity?: number;
   addToWishlist: boolean;
 }

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -169,8 +169,11 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
                   _ed.image_uris?.normal ||
                   _ed.card_faces?.[0]?.image_uris?.normal ||
                   '',
-                language: _language,
-                quantity: _quantity === 'indiferente' ? 1 : (_quantity as number),
+                language: _language === 'indiferente' ? undefined : _language,
+                quantity:
+                  _quantity === 'indiferente'
+                    ? undefined
+                    : (_quantity as number),
                 addToWishlist: _wishlist,
               },
               user.access_token,

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -112,8 +112,8 @@ export async function findSellers(
     cardId: string;
     cardName: string;
     imageUrl?: string;
-    language: string;
-    quantity: number;
+    language?: string;
+    quantity?: number;
     addToWishlist: boolean;
   },
   token: string,


### PR DESCRIPTION
## Summary
- allow find-sellers endpoint to omit language and quantity
- default wishlist creation values when omitted
- update frontend API and logic to send optional language/quantity

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in trade-web *(fails: missing deps)*
- `npm run lint` in backend *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866dfb6e5a88320b2012f83133ada15