### PR TITLE
Fix edition selection and propagate filters

### DIFF
--- a/apps/trade-web/src/CardDetails.tsx
+++ b/apps/trade-web/src/CardDetails.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useLocation } from 'react-router-dom'
 import {
   Box,
   Container,
@@ -21,8 +21,12 @@ export type CardDetailsProps = {
 
 export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
   const { id } = useParams()
+  const location = useLocation()
   const [card, setCard] = useState<any | null>(null)
   const [sellers, setSellers] = useState<any[]>([])
+  const params = new URLSearchParams(location.search)
+  const quantity = params.get('quantity')
+  const language = params.get('language')
 
   useEffect(() => {
     if (!id) return
@@ -34,9 +38,19 @@ export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
   useEffect(() => {
     if (!id) return
     getSellers(id, user.access_token)
-      .then(setSellers)
+      .then((data) => {
+        let filtered = data
+        if (quantity) {
+          const q = parseInt(quantity, 10)
+          filtered = filtered.filter((s: any) => s.quantity >= q)
+        }
+        if (language) {
+          filtered = filtered.filter((s: any) => s.language === language)
+        }
+        setSellers(filtered)
+      })
       .catch((err) => console.warn(err))
-  }, [id, user.access_token])
+  }, [id, user.access_token, location.search])
 
   const imgSrc =
     card?.image_uris?.normal || card?.card_faces?.[0]?.image_uris?.normal || null

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -26,7 +26,7 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
   const [query, setQuery] = useState("");
   const [selectedCard, setSelectedCard] = useState<CardWithEditions | null>(null);
   const [editionOpen, setEditionOpen] = useState(false);
-  const [ setSelectedEdition] = useState<any | null>(null);
+  const [selectedEdition, setSelectedEdition] = useState<any | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -181,7 +181,14 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
           } catch (err) {
             console.warn(err);
           } finally {
-            navigate(`/cards/${_ed.id}`);
+            const params = new URLSearchParams();
+            if (_language !== 'indiferente') {
+              params.set('language', _language);
+            }
+            if (_quantity !== 'indiferente') {
+              params.set('quantity', String(_quantity));
+            }
+            navigate(`/cards/${_ed.id}?${params.toString()}`);
           }
         }}
       />


### PR DESCRIPTION
## Summary
- fix state hook in SearchResults so value is readable
- include query params when navigating to CardDetails
- filter sellers in CardDetails using query params

## Testing
- `npm run lint --workspace trade-web` *(fails: Cannot find package '@eslint/js')*
- `npm test -w apps/backend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e70a8e58832086284da2fe060e66