### PR TITLE
Update inventory modal quantity defaults

### DIFF
--- a/apps/trade-web/src/InventoryModal.tsx
+++ b/apps/trade-web/src/InventoryModal.tsx
@@ -28,7 +28,7 @@ export const InventoryModal = ({
 }: InventoryModalProps) => {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const [language, setLanguage] = useState('indiferente')
-  const [quantity, setQuantity] = useState<Quantity>('indiferente')
+  const [quantity, setQuantity] = useState<Quantity>(1)
   const LANGUAGES = [
     'indiferente',
     'EN',
@@ -42,7 +42,7 @@ export const InventoryModal = ({
     'RU',
     'ZH',
   ]
-  const QUANTITIES: Quantity[] = ['indiferente', 1, 2, 3, 4]
+  const QUANTITIES: Quantity[] = [1, 2, 3, 4]
 
   const handleConfirm = () => {
     if (selectedIndex != null && onConfirm) {

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -211,7 +211,6 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
         onConfirm={async (_ed, _language, _quantity) => {
           setSelectedEdition(_ed)
           setSellOpen(false)
-          if (_quantity === 'indiferente') return
           try {
             await createInventoryItem(
               {
@@ -221,7 +220,8 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
                   _ed.image_uris?.normal ||
                   _ed.card_faces?.[0]?.image_uris?.normal ||
                   '',
-                quantity: _quantity as number,
+                quantity:
+                  typeof _quantity === 'number' ? _quantity : 1,
               },
               user.access_token,
             )


### PR DESCRIPTION
## Summary
- set default quantity in `InventoryModal` to 1
- restrict quantity options to numeric values
- always send a numeric quantity when creating inventory items

## Testing
- `npm run lint -w apps/trade-web` *(fails: Cannot find package '@eslint/js')*
- `npm test -w apps/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866edc449a48320b51006e0fffd0d01