### PR TITLE
Add foil, signed and comment on sell modal

### DIFF
--- a/apps/backend/src/collection/controller/inventory.controller.ts
+++ b/apps/backend/src/collection/controller/inventory.controller.ts
@@ -41,6 +41,9 @@ export class InventoryController {
         imageUrl: dto.imageUrl,
       } as any,
       quantity: dto.quantity,
+      foil: Boolean(dto.foil),
+      signed: Boolean(dto.signed),
+      comment: dto.comment,
     });
   }
 

--- a/apps/backend/src/collection/dto/create-inventory-item.dto.ts
+++ b/apps/backend/src/collection/dto/create-inventory-item.dto.ts
@@ -3,4 +3,7 @@ export class CreateInventoryItemDto {
   quantity: number;
   cardName: string;
   imageUrl?: string;
+  foil?: boolean;
+  signed?: boolean;
+  comment?: string;
 }

--- a/apps/backend/src/collection/entity/inventory-item.entity.ts
+++ b/apps/backend/src/collection/entity/inventory-item.entity.ts
@@ -15,4 +15,13 @@ export class InventoryItem {
 
   @Column({ default: 1 })
   quantity: number;
+
+  @Column({ default: false })
+  foil: boolean;
+
+  @Column({ default: false })
+  signed: boolean;
+
+  @Column({ nullable: true })
+  comment?: string;
 }

--- a/apps/trade-web/src/CardDetails.tsx
+++ b/apps/trade-web/src/CardDetails.tsx
@@ -111,11 +111,11 @@ export const CardDetails = ({ user, onLogout }: CardDetailsProps) => {
                   {sellers.map((s) => (
                     <TableRow key={s.id}>
                       <TableCell>{s.user?.username}</TableCell>
-                      <TableCell>No</TableCell>
-                      <TableCell>No</TableCell>
-                      <TableCell></TableCell>
+                      <TableCell>{s.foil ? 'Sí' : 'No'}</TableCell>
+                      <TableCell>{s.signed ? 'Sí' : 'No'}</TableCell>
+                      <TableCell>{s.comment || ''}</TableCell>
                       <TableCell>{s.quantity}</TableCell>
-                      <TableCell>indiferente</TableCell>
+                      <TableCell>{s.language || 'indiferente'}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>

--- a/apps/trade-web/src/InventoryModal.tsx
+++ b/apps/trade-web/src/InventoryModal.tsx
@@ -10,6 +10,9 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  FormControlLabel,
+  Checkbox,
+  TextField,
 } from '@mui/material'
 import type { Quantity } from './CardEditionModal'
 
@@ -17,7 +20,14 @@ export type InventoryModalProps = {
   open: boolean
   editions: any[]
   onClose: () => void
-  onConfirm?: (edition: any, language: string, quantity: Quantity) => void
+  onConfirm?: (
+    edition: any,
+    language: string,
+    quantity: Quantity,
+    foil: boolean,
+    signed: boolean,
+    comment: string,
+  ) => void
 }
 
 export const InventoryModal = ({
@@ -29,6 +39,9 @@ export const InventoryModal = ({
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const [language, setLanguage] = useState('indiferente')
   const [quantity, setQuantity] = useState<Quantity>(1)
+  const [foil, setFoil] = useState(false)
+  const [signed, setSigned] = useState(false)
+  const [comment, setComment] = useState('')
   const LANGUAGES = [
     'indiferente',
     'EN',
@@ -46,7 +59,14 @@ export const InventoryModal = ({
 
   const handleConfirm = () => {
     if (selectedIndex != null && onConfirm) {
-      onConfirm(editions[selectedIndex], language, quantity)
+      onConfirm(
+        editions[selectedIndex],
+        language,
+        quantity,
+        foil,
+        signed,
+        comment,
+      )
     }
     onClose()
   }
@@ -151,6 +171,34 @@ export const InventoryModal = ({
                 ))}
               </Select>
             </FormControl>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={foil}
+                  onChange={(e) => setFoil(e.target.checked)}
+                  color="warning"
+                />
+              }
+              label="Foil"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={signed}
+                  onChange={(e) => setSigned(e.target.checked)}
+                  color="warning"
+                />
+              }
+              label="Firmada"
+            />
+            <TextField
+              label="Comentario"
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              size="small"
+              color="warning"
+              sx={{ minWidth: 200 }}
+            />
           </Box>
           <Button
             variant="contained"

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -208,7 +208,14 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
         open={sellOpen}
         editions={selectedCard?.editions ?? []}
         onClose={() => setSellOpen(false)}
-        onConfirm={async (_ed, _language, _quantity) => {
+        onConfirm={async (
+          _ed,
+          _language,
+          _quantity,
+          _foil,
+          _signed,
+          _comment,
+        ) => {
           setSelectedEdition(_ed)
           setSellOpen(false)
           try {
@@ -222,6 +229,9 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
                   '',
                 quantity:
                   typeof _quantity === 'number' ? _quantity : 1,
+                foil: _foil,
+                signed: _signed,
+                comment: _comment,
               },
               user.access_token,
             )

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -168,7 +168,15 @@ export async function getInventory(token: string) {
 }
 
 export async function createInventoryItem(
-  data: { cardId: string; cardName: string; imageUrl?: string; quantity: number },
+  data: {
+    cardId: string;
+    cardName: string;
+    imageUrl?: string;
+    quantity: number;
+    foil?: boolean;
+    signed?: boolean;
+    comment?: string;
+  },
   token: string,
 ) {
   const response = await jsonFetch(API_URL + "/inventory", {


### PR DESCRIPTION
## Summary
- expand inventory item entity with `foil`, `signed` and `comment`
- accept the new properties through DTO and controller
- update API client for new fields
- extend sell modal to let users specify foil, signed and comment
- show these details in card seller list

## Testing
- `npx tsc -b apps/trade-web/tsconfig.json --noEmit` *(fails: Cannot find type definition file)*
- `npm test -w apps/backend` *(fails: jest: not found)*
- `npm test -w apps/trade-web` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_687247599e208320857b2b7d3bb6b66f