### PR TITLE
Add user conversations chat feature

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { UserModule } from './user/user.module';
 import { CardModule } from './card/card.module';
 import { CollectionModule } from './collection/collection.module';
 import { ProfileModule } from './profile/profile.module';
+import { ConversationModule } from './conversation/conversation.module';
 
 @Module({
   imports: [
@@ -38,7 +39,8 @@ import { ProfileModule } from './profile/profile.module';
     AuthModule,
     CardModule,
     CollectionModule,
-    ProfileModule
+    ProfileModule,
+    ConversationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/conversation/controller/conversation.controller.ts
+++ b/apps/backend/src/conversation/controller/conversation.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Post, Body, Param, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ConversationService } from '../service/conversation.service';
+import { CreateMessageDto } from '../dto/create-message.dto';
+
+@UseGuards(AuthGuard('jwt'))
+@Controller('conversations')
+export class ConversationController {
+  constructor(private readonly service: ConversationService) {}
+
+  @Get()
+  findAll(@Request() req) {
+    return this.service.findConversations(req.user.userId);
+  }
+
+  @Get(':id/messages')
+  findMessages(
+    @Request() req,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ) {
+    return this.service.getMessages(req.user.userId, id);
+  }
+
+  @Post(':id/messages')
+  sendMessage(
+    @Request() req,
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: CreateMessageDto,
+  ) {
+    return this.service.sendMessage(req.user.userId, id, dto.content);
+  }
+}

--- a/apps/backend/src/conversation/conversation.module.ts
+++ b/apps/backend/src/conversation/conversation.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Conversation } from './entity/conversation.entity';
+import { Message } from './entity/message.entity';
+import { ConversationRepository } from './repository/conversation.repository';
+import { MessageRepository } from './repository/message.repository';
+import { ConversationService } from './service/conversation.service';
+import { ConversationController } from './controller/conversation.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Conversation, Message])],
+  providers: [ConversationRepository, MessageRepository, ConversationService],
+  controllers: [ConversationController],
+  exports: [ConversationService],
+})
+export class ConversationModule {}

--- a/apps/backend/src/conversation/dto/create-message.dto.ts
+++ b/apps/backend/src/conversation/dto/create-message.dto.ts
@@ -1,0 +1,3 @@
+export class CreateMessageDto {
+  content: string;
+}

--- a/apps/backend/src/conversation/entity/conversation.entity.ts
+++ b/apps/backend/src/conversation/entity/conversation.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { User } from 'src/user/entity/user.entity';
+
+@Entity()
+export class Conversation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, { eager: true })
+  user1: User;
+
+  @ManyToOne(() => User, { eager: true })
+  user2: User;
+}

--- a/apps/backend/src/conversation/entity/message.entity.ts
+++ b/apps/backend/src/conversation/entity/message.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import { Conversation } from './conversation.entity';
+import { User } from 'src/user/entity/user.entity';
+
+@Entity()
+export class Message {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Conversation, { eager: true })
+  conversation: Conversation;
+
+  @ManyToOne(() => User, { eager: true })
+  sender: User;
+
+  @Column()
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/backend/src/conversation/repository/conversation.repository.ts
+++ b/apps/backend/src/conversation/repository/conversation.repository.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Conversation } from '../entity/conversation.entity';
+
+@Injectable()
+export class ConversationRepository {
+  constructor(
+    @InjectRepository(Conversation)
+    private readonly repository: Repository<Conversation>,
+  ) {}
+
+  findByUser(userId: string): Promise<Conversation[]> {
+    return this.repository.find({
+      where: [{ user1: { id: userId } }, { user2: { id: userId } }],
+    });
+  }
+
+  findById(id: string): Promise<Conversation | null> {
+    return this.repository.findOne({ where: { id } });
+  }
+
+  async createAndSave(data: Partial<Conversation>): Promise<Conversation> {
+    const conversation = this.repository.create(data);
+    return this.repository.save(conversation);
+  }
+}

--- a/apps/backend/src/conversation/repository/message.repository.ts
+++ b/apps/backend/src/conversation/repository/message.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Message } from '../entity/message.entity';
+
+@Injectable()
+export class MessageRepository {
+  constructor(
+    @InjectRepository(Message)
+    private readonly repository: Repository<Message>,
+  ) {}
+
+  findByConversation(conversationId: string): Promise<Message[]> {
+    return this.repository.find({
+      where: { conversation: { id: conversationId } },
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  async createAndSave(data: Partial<Message>): Promise<Message> {
+    const msg = this.repository.create(data);
+    return this.repository.save(msg);
+  }
+}

--- a/apps/backend/src/conversation/service/conversation.service.ts
+++ b/apps/backend/src/conversation/service/conversation.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { ConversationRepository } from '../repository/conversation.repository';
+import { MessageRepository } from '../repository/message.repository';
+import { Conversation } from '../entity/conversation.entity';
+import { Message } from '../entity/message.entity';
+
+@Injectable()
+export class ConversationService {
+  constructor(
+    private readonly conversationRepo: ConversationRepository,
+    private readonly messageRepo: MessageRepository,
+  ) {}
+
+  findConversations(userId: string): Promise<Conversation[]> {
+    return this.conversationRepo.findByUser(userId);
+  }
+
+  async getMessages(userId: string, conversationId: string): Promise<Message[]> {
+    const conv = await this.conversationRepo.findById(conversationId);
+    if (!conv || (conv.user1.id !== userId && conv.user2.id !== userId)) {
+      throw new ForbiddenException();
+    }
+    return this.messageRepo.findByConversation(conversationId);
+  }
+
+  async sendMessage(
+    userId: string,
+    conversationId: string,
+    content: string,
+  ): Promise<Message> {
+    const conv = await this.conversationRepo.findById(conversationId);
+    if (!conv || (conv.user1.id !== userId && conv.user2.id !== userId)) {
+      throw new ForbiddenException();
+    }
+    return this.messageRepo.createAndSave({
+      conversation: conv,
+      sender: { id: userId } as any,
+      content,
+    });
+  }
+}

--- a/apps/trade-web/src/App.tsx
+++ b/apps/trade-web/src/App.tsx
@@ -9,6 +9,8 @@ import { CardDetails } from './CardDetails'
 import { Wishlist } from './Wishlist'
 import { Sales } from './Sales'
 import Register from './Register'
+import Conversations from './Conversations'
+import Chat from './Chat'
 
 function App() {
   const [user, userSet] = useState<AuthUser | null>(() => {
@@ -96,6 +98,26 @@ function App() {
             element={
               user ? (
                 <Wishlist user={user} onLogout={handleLogout} />
+              ) : (
+                <Navigate to="/login" replace />
+              )
+            }
+          />
+          <Route
+            path="/conversations"
+            element={
+              user ? (
+                <Conversations user={user} onLogout={handleLogout} />
+              ) : (
+                <Navigate to="/login" replace />
+              )
+            }
+          />
+          <Route
+            path="/conversations/:id"
+            element={
+              user ? (
+                <Chat user={user} onLogout={handleLogout} />
               ) : (
                 <Navigate to="/login" replace />
               )

--- a/apps/trade-web/src/Chat.tsx
+++ b/apps/trade-web/src/Chat.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { Box, Container, Typography, List, ListItem, TextField, Button } from '@mui/material';
+import NavBar from './NavBar';
+import type { AuthUser } from './Login';
+import { getMessages, sendMessage } from './api';
+import { useParams } from 'react-router-dom';
+
+export type ChatProps = {
+  user: AuthUser;
+  onLogout: () => void;
+};
+
+export const Chat = ({ user, onLogout }: ChatProps) => {
+  const { id } = useParams();
+  const [messages, setMessages] = useState<any[]>([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    getMessages(id, user.access_token)
+      .then(setMessages)
+      .catch((err) => console.warn(err));
+  }, [id, user.access_token]);
+
+  const handleSend = async () => {
+    if (!id || !text.trim()) return;
+    try {
+      const msg = await sendMessage(id, text.trim(), user.access_token);
+      setMessages([...messages, msg]);
+      setText('');
+    } catch (err) {
+      console.warn(err);
+    }
+  };
+
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <NavBar user={user} onLogout={onLogout} />
+      <Container sx={{ mt: 2, flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
+        <Typography variant='h6' sx={{ mb: 2 }}>Chat</Typography>
+        <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
+          <List>
+            {messages.map((msg: any) => (
+              <ListItem key={msg.id}>{msg.sender?.username}: {msg.content}</ListItem>
+            ))}
+          </List>
+        </Box>
+        <Box sx={{ display: 'flex', mt: 1 }}>
+          <TextField
+            fullWidth
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSend();
+            }}
+          />
+          <Button onClick={handleSend} sx={{ ml: 1 }} variant='contained'>Enviar</Button>
+        </Box>
+      </Container>
+    </Box>
+  );
+};
+
+export default Chat;

--- a/apps/trade-web/src/Conversations.tsx
+++ b/apps/trade-web/src/Conversations.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { Box, Container, Typography, List, ListItem, ListItemButton } from '@mui/material';
+import NavBar from './NavBar';
+import type { AuthUser } from './Login';
+import { getConversations } from './api';
+import { useNavigate } from 'react-router-dom';
+
+export type ConversationsProps = {
+  user: AuthUser;
+  onLogout: () => void;
+};
+
+export const Conversations = ({ user, onLogout }: ConversationsProps) => {
+  const [conversations, setConversations] = useState<any[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getConversations(user.access_token)
+      .then(setConversations)
+      .catch((err) => console.warn(err));
+  }, [user.access_token]);
+
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <NavBar user={user} onLogout={onLogout} />
+      <Container sx={{ mt: 2, flexGrow: 1 }}>
+        <Typography variant='h6' sx={{ mb: 2 }}>
+          Conversaciones
+        </Typography>
+        <List>
+          {conversations.map((conv: any) => (
+            <ListItem key={conv.id} disablePadding>
+              <ListItemButton onClick={() => navigate(`/conversations/${conv.id}`)}>
+                {conv.user1?.username} - {conv.user2?.username}
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Container>
+    </Box>
+  );
+};
+
+export default Conversations;

--- a/apps/trade-web/src/NavBar.tsx
+++ b/apps/trade-web/src/NavBar.tsx
@@ -65,6 +65,7 @@ export const NavBar = ({ user, onLogout }: NavBarProps) => {
   const menuItems = [
     { text: "Ventas", path: "/sales" },
     { text: "Lista de deseos", path: "/wishlist" },
+    { text: "Conversaciones", path: "/conversations" },
     { text: "Notificaciones", path: "/notifications" },
   ];
 

--- a/apps/trade-web/src/api/index.ts
+++ b/apps/trade-web/src/api/index.ts
@@ -217,6 +217,48 @@ export async function deleteWishlistItem(id: string, token: string) {
   }
 }
 
+export async function getConversations(token: string) {
+  const response = await fetch(`${API_URL}/conversations`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch conversations');
+  }
+
+  return await response.json();
+}
+
+export async function getMessages(id: string, token: string) {
+  const response = await fetch(
+    `${API_URL}/conversations/${encodeURIComponent(id)}/messages`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch messages');
+  }
+
+  return await response.json();
+}
+
+export async function sendMessage(id: string, content: string, token: string) {
+  const response = await jsonFetch(
+    `${API_URL}/conversations/${encodeURIComponent(id)}/messages`,
+    {
+      method: 'POST',
+      payload: { content },
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to send message');
+  }
+
+  return await response.json();
+}
+
 export function authApi(token: string) {
   return {
     async me(token: string) {


### PR DESCRIPTION
## Summary
- add `conversation` module on the backend with entities, service and controller
- expose new conversation API endpoints
- extend API client with conversation functions
- add Conversations list and Chat view to the frontend
- register new routes and menu entry for conversations

## Testing
- `npm test --workspace apps/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c2738a3ec832086e9ab6a1be1e01d