### PR TITLE
Add emoji picker to chat

### DIFF
--- a/apps/trade-web/package.json
+++ b/apps/trade-web/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.17.1",
     "@mui/material": "^5.15.11",
+    "emoji-picker-react": "^5.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",

--- a/apps/trade-web/src/Chat.tsx
+++ b/apps/trade-web/src/Chat.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Box, Container, Typography, List, ListItem, TextField, Button } from '@mui/material';
+import { Box, Container, Typography, List, ListItem, TextField, Button, IconButton } from '@mui/material';
+import InsertEmoticonIcon from '@mui/icons-material/InsertEmoticon';
+import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
 import NavBar from './NavBar';
 import type { AuthUser } from './Login';
 import { getMessages, sendMessage } from './api';
@@ -14,6 +16,7 @@ export const Chat = ({ user, onLogout }: ChatProps) => {
   const { id } = useParams();
   const [messages, setMessages] = useState<any[]>([]);
   const [text, setText] = useState('');
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -33,6 +36,10 @@ export const Chat = ({ user, onLogout }: ChatProps) => {
     }
   };
 
+  const handleEmojiClick = (emojiData: EmojiClickData) => {
+    setText((prev) => prev + emojiData.emoji);
+  };
+
   return (
     <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
       <NavBar user={user} onLogout={onLogout} />
@@ -45,7 +52,7 @@ export const Chat = ({ user, onLogout }: ChatProps) => {
             ))}
           </List>
         </Box>
-        <Box sx={{ display: 'flex', mt: 1 }}>
+        <Box sx={{ display: 'flex', mt: 1, alignItems: 'center', position: 'relative' }}>
           <TextField
             fullWidth
             value={text}
@@ -53,8 +60,22 @@ export const Chat = ({ user, onLogout }: ChatProps) => {
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSend();
             }}
+            InputProps={{
+              endAdornment: (
+                <IconButton onClick={() => setPickerOpen((prev) => !prev)}>
+                  <InsertEmoticonIcon />
+                </IconButton>
+              ),
+            }}
           />
-          <Button onClick={handleSend} sx={{ ml: 1 }} variant='contained'>Enviar</Button>
+          <Button onClick={handleSend} sx={{ ml: 1 }} variant='contained'>
+            Enviar
+          </Button>
+          {pickerOpen && (
+            <Box sx={{ position: 'absolute', bottom: 56, right: 0, zIndex: 1 }}>
+              <EmojiPicker onEmojiClick={handleEmojiClick} height={350} />
+            </Box>
+          )}
         </Box>
       </Container>
     </Box>


### PR DESCRIPTION
## Summary
- add `emoji-picker-react` dependency for React emoji support
- enhance chat input with emoji picker and icon button

## Testing
- `npm --workspace apps/trade-web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --workspace apps/backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c32465cac8320b46303721d292459