### PR TITLE
Fix emoji picker import

### DIFF
--- a/apps/trade-web/src/Chat.tsx
+++ b/apps/trade-web/src/Chat.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Box, Container, Typography, List, ListItem, TextField, Button, IconButton } from '@mui/material';
 import InsertEmoticonIcon from '@mui/icons-material/InsertEmoticon';
-import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
+import EmojiPicker, { type EmojiClickData } from 'emoji-picker-react';
 import NavBar from './NavBar';
 import type { AuthUser } from './Login';
 import { getMessages, sendMessage } from './api';


### PR DESCRIPTION
## Summary
- mark `EmojiClickData` import as type-only

## Testing
- `npm test` *(fails: script missing)*
- `npm test` in `apps/backend` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c343c81ec832095d78d5597eee297