### PR TITLE
Improve mobile responsive design

### DIFF
--- a/apps/trade-web/src/CardEditionModal.tsx
+++ b/apps/trade-web/src/CardEditionModal.tsx
@@ -12,6 +12,8 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  useTheme,
+  useMediaQuery,
 } from '@mui/material'
 
 export type Quantity = 'indiferente' | 1 | 2 | 3 | 4
@@ -38,6 +40,8 @@ export const CardEditionModal = ({
   const [addToWishlist, setAddToWishlist] = useState(false)
   const [language, setLanguage] = useState('indiferente')
   const [quantity, setQuantity] = useState<Quantity>('indiferente')
+  const theme = useTheme()
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'))
   const LANGUAGES = [
     'indiferente',
     'EN',
@@ -61,7 +65,7 @@ export const CardEditionModal = ({
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth fullScreen={fullScreen}>
       <DialogTitle>Selecciona una edición</DialogTitle>
       <DialogContent>
         <Box

--- a/apps/trade-web/src/NavBar.tsx
+++ b/apps/trade-web/src/NavBar.tsx
@@ -122,7 +122,11 @@ export const NavBar = ({ user, onLogout }: NavBarProps) => {
                 </InputAdornment>
               ),
             }}
-            sx={{ maxWidth: 400, width: "100%", ml: 2 }}
+            sx={{
+              width: '100%',
+              maxWidth: { sm: 400 },
+              ml: { xs: 1, sm: 2 },
+            }}
           />
         </Box>
         <Box

--- a/apps/trade-web/src/Sales.tsx
+++ b/apps/trade-web/src/Sales.tsx
@@ -4,6 +4,7 @@ import {
   Container,
   Typography,
   Table,
+  TableContainer,
   TableHead,
   TableRow,
   TableCell,
@@ -42,6 +43,7 @@ export const Sales = ({ user, onLogout }: SalesProps) => {
         <Typography variant='h6' sx={{ mb: 2 }}>
           Ventas
         </Typography>
+        <TableContainer sx={{ overflowX: 'auto' }}>
         <Table size='small'>
           <TableHead>
             <TableRow>
@@ -96,6 +98,7 @@ export const Sales = ({ user, onLogout }: SalesProps) => {
             ))}
           </TableBody>
         </Table>
+        </TableContainer>
         <Dialog open={Boolean(deleteId)} onClose={() => setDeleteId(null)}>
           <DialogTitle>
             ¿Estás seguro de que quieres eliminar esta carta?

--- a/apps/trade-web/src/SalesModal.tsx
+++ b/apps/trade-web/src/SalesModal.tsx
@@ -13,6 +13,8 @@ import {
   FormControlLabel,
   Checkbox,
   TextField,
+  useTheme,
+  useMediaQuery,
 } from '@mui/material'
 import type { Quantity } from './CardEditionModal'
 
@@ -42,6 +44,8 @@ export const SalesModal = ({
   const [foil, setFoil] = useState(false)
   const [signed, setSigned] = useState(false)
   const [comment, setComment] = useState('')
+  const theme = useTheme()
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'))
   const LANGUAGES = [
     'indiferente',
     'EN',
@@ -72,7 +76,7 @@ export const SalesModal = ({
   }
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth fullScreen={fullScreen}>
       <DialogTitle>Selecciona una edición</DialogTitle>
       <DialogContent>
         <Box

--- a/apps/trade-web/src/SearchResults.tsx
+++ b/apps/trade-web/src/SearchResults.tsx
@@ -57,7 +57,11 @@ export const SearchResults = ({ user, onLogout }: SearchResultsProps) => {
         <Box
           sx={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(4, 1fr)',
+            gridTemplateColumns: {
+              xs: 'repeat(2, 1fr)',
+              sm: 'repeat(3, 1fr)',
+              md: 'repeat(4, 1fr)',
+            },
             columnGap: 0.25,
             rowGap: 1,
           }}

--- a/apps/trade-web/src/Wishlist.tsx
+++ b/apps/trade-web/src/Wishlist.tsx
@@ -4,6 +4,7 @@ import {
   Container,
   Typography,
   Table,
+  TableContainer,
   TableHead,
   TableRow,
   TableCell,
@@ -43,6 +44,7 @@ export const Wishlist = ({ user, onLogout }: WishlistProps) => {
         <Typography variant="h6" sx={{ mb: 2 }}>
           Mi lista de deseos
         </Typography>
+        <TableContainer sx={{ overflowX: 'auto' }}>
         <Table size="small">
           <TableHead>
             <TableRow>
@@ -95,6 +97,7 @@ export const Wishlist = ({ user, onLogout }: WishlistProps) => {
             ))}
           </TableBody>
         </Table>
+        </TableContainer>
         <Dialog open={Boolean(deleteId)} onClose={() => setDeleteId(null)}>
           <DialogTitle>
             ¿Estás seguro de que quieres eliminar esta carta?


### PR DESCRIPTION
## Summary
- adjust search results grid layout using responsive breakpoints
- tweak search field spacing for small screens
- make wishlist and sales tables scrollable on mobile
- show card edition and sales modals fullscreen on small displays

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_687c3b02ffb8832093c2d9453f49b6e3