### PR TITLE
Adjust chat input spacing

### DIFF
--- a/apps/trade-web/src/Chat.tsx
+++ b/apps/trade-web/src/Chat.tsx
@@ -43,7 +43,7 @@ export const Chat = ({ user, onLogout }: ChatProps) => {
   return (
     <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
       <NavBar user={user} onLogout={onLogout} />
-      <Container sx={{ mt: 2, flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
+      <Container sx={{ mt: 2, flexGrow: 1, display: 'flex', flexDirection: 'column', pb: 3 }}>
         <Typography variant='h6' sx={{ mb: 2 }}>Chat</Typography>
         <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
           <List>


### PR DESCRIPTION
## Summary
- tweak chat screen layout so message input is not flush to screen bottom

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3dc49a4c8320a8429f7cd8022762