### PR TITLE
Fix emoji display in chat

### DIFF
--- a/apps/trade-web/src/index.css
+++ b/apps/trade-web/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: system-ui, Avenir, Helvetica, Arial, 'Segoe UI Emoji', 'Noto Color Emoji', 'EmojiSymbols', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/apps/trade-web/src/theme.ts
+++ b/apps/trade-web/src/theme.ts
@@ -7,6 +7,10 @@ export const darkTheme = createTheme({
       main: '#ffffff',
     },
   },
+  typography: {
+    fontFamily:
+      "Roboto, Helvetica, Arial, 'Segoe UI Emoji', 'Noto Color Emoji', 'EmojiSymbols', sans-serif",
+  },
   shape: {
     borderRadius: 24,
   },


### PR DESCRIPTION
## Summary
- include emoji fonts in global styles
- add emoji fonts to MUI theme

## Testing
- `npm --workspace apps/backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3f4ddc208320a942b8aa47629329